### PR TITLE
feat(homepage): default language by visitor country

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,6 +3,10 @@
   command = "node scripts/build-cinematic-site.mjs"
   environment = { NODE_VERSION = "22" }
 
+[[edge_functions]]
+  function = "padiem-geo-language"
+  path = "/"
+
 [[ignore_files]]
   files = [
     "hugo.zip",

--- a/netlify/edge-functions/padiem-geo-language.ts
+++ b/netlify/edge-functions/padiem-geo-language.ts
@@ -1,0 +1,21 @@
+import type { Context } from "@netlify/edge-functions";
+
+export default async (_request: Request, context: Context) => {
+  const response = await context.next();
+  const country = context.geo?.country?.code?.toUpperCase() || "ZZ";
+  const headers = new Headers(response.headers);
+
+  // First-party, non-HttpOnly cookie so the bootstrap script can read it before
+  // the existing KO/EN runtime initializes. Session scope avoids stale location
+  // data across future browser sessions.
+  headers.append(
+    "Set-Cookie",
+    `padiem-geo-country=${encodeURIComponent(country)}; Path=/; SameSite=Lax; Secure`,
+  );
+
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+};

--- a/scripts/build-cinematic-site.mjs
+++ b/scripts/build-cinematic-site.mjs
@@ -46,9 +46,10 @@ const seoHead = [
 ].join("");
 
 // The Netlify Edge Function writes the visitor country into a first-party cookie.
-// Seed the existing language runtime only when the visitor has not already made
-// an explicit KO/EN choice. Existing manual choices therefore always win.
-const geoLanguageBootstrap = `<script>(()=>{try{if(localStorage.getItem("padiem-language"))return;const match=document.cookie.match(/(?:^|;\\s*)padiem-geo-country=([^;]+)/);if(!match)return;const country=decodeURIComponent(match[1]).toUpperCase();localStorage.setItem("padiem-language",country==="KR"?"ko":"en");}catch{}})();</script>`;
+// Existing padiem-language values only come from an explicit KO/EN click, so they
+// always win. GeoIP is injected just long enough for the existing language runtime
+// to read it, then removed so a later visit can follow the visitor's current country.
+const geoLanguageBootstrap = `<script>(()=>{try{if(localStorage.getItem("padiem-language"))return;const match=document.cookie.match(/(?:^|;\\s*)padiem-geo-country=([^;]+)/);if(!match)return;const country=decodeURIComponent(match[1]).toUpperCase();localStorage.setItem("padiem-language",country==="KR"?"ko":"en");addEventListener("DOMContentLoaded",()=>localStorage.removeItem("padiem-language"),{once:true});}catch{}})();</script>`;
 
 html = html.replace(oldTitle, seoHead);
 html = html.replace(languageScript, `${geoLanguageBootstrap}${languageScript}`);

--- a/scripts/build-cinematic-site.mjs
+++ b/scripts/build-cinematic-site.mjs
@@ -22,12 +22,16 @@ let html = readFileSync(sourceHtml, "utf8");
 
 const oldTitle = "<title>PADIEM Cinematic Pearl Glass Demo V2</title>";
 const newTitle = "<title>PADIEM | AI로 일을 다시 설계합니다</title>";
+const languageScript = '<script src="/js/padiem-cinematic-v2-2.js"></script>';
 
 if (!html.includes(oldTitle)) {
   throw new Error("Expected cinematic source title was not found; refusing to publish an unreviewed head change.");
 }
 if (html.includes('rel="canonical"')) {
   throw new Error("Canonical already exists in the cinematic source; update this build script before publishing.");
+}
+if (!html.includes(languageScript)) {
+  throw new Error("Expected language runtime script was not found; refusing to publish without geo-language bootstrap.");
 }
 
 const seoHead = [
@@ -41,7 +45,13 @@ const seoHead = [
   '<meta property="og:url" content="https://padiem.net/"/>',
 ].join("");
 
+// The Netlify Edge Function writes the visitor country into a first-party cookie.
+// Seed the existing language runtime only when the visitor has not already made
+// an explicit KO/EN choice. Existing manual choices therefore always win.
+const geoLanguageBootstrap = `<script>(()=>{try{if(localStorage.getItem("padiem-language"))return;const match=document.cookie.match(/(?:^|;\\s*)padiem-geo-country=([^;]+)/);if(!match)return;const country=decodeURIComponent(match[1]).toUpperCase();localStorage.setItem("padiem-language",country==="KR"?"ko":"en");}catch{}})();</script>`;
+
 html = html.replace(oldTitle, seoHead);
+html = html.replace(languageScript, `${geoLanguageBootstrap}${languageScript}`);
 writeFileSync(join(publicDir, "index.html"), html, "utf8");
 
 for (const dir of ["css", "js", "images"]) {


### PR DESCRIPTION
## 목적

PADIEM 홈페이지의 최초 언어 선택을 브라우저 언어 중심에서 접속 국가 중심으로 변경합니다.

## 동작 우선순위

1. 사용자가 기존에 KO/EN을 직접 선택한 경우 그 선택을 계속 우선
2. 명시적 선택이 없고 Netlify GeoIP 국가가 `KR`이면 한국어
3. 명시적 선택이 없고 `KR` 외 국가이면 영어
4. GeoIP가 없는 로컬/예외 환경에서는 기존 브라우저 언어 fallback 유지

## 구현

- Netlify Edge Function에서 `context.geo.country.code`를 읽어 first-party session cookie로 전달
- canonical build에서 기존 language runtime 직전에 짧은 bootstrap 삽입
- GeoIP 자동 선택은 초기화에만 사용하고 DOM ready 후 제거하여 위치 변경 시 stale preference가 남지 않도록 처리
- 기존 수동 KO/EN 선택(localStorage)은 변경하지 않음
- `/ko`, `/en` URL 분리 없이 현재 `/` canonical 구조 유지

## 범위

- `netlify/edge-functions/padiem-geo-language.ts`
- `netlify.toml`
- `scripts/build-cinematic-site.mjs`

## 사전 검증

- Edge Function TypeScript shape/syntax: PASS
- KR => KO: PASS
- non-KR => EN: PASS
- existing manual KO/EN > GeoIP: PASS
- auto GeoIP choice non-persistent: PASS

Draft 상태에서 Netlify Deploy Preview / exact-head 상태를 확인한 뒤 병합합니다.