### PR TITLE
PADIEM Cinematic Worlds — build/render QA (draft)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # PADIEM Website
 
-`18-padiemai` is the source repository for the live `padiem.net` homepage.
+`18-padiemai` is the source repository for the public `padiem.net` website.
 
 ## Current production path
 
 This project is **not** a Hugo/PaperMod site in the active deployment path.
 
-Netlify builds the current cinematic homepage with:
+Netlify builds the cinematic site with:
 
 ```toml
 [build]
@@ -14,29 +14,133 @@ Netlify builds the current cinematic homepage with:
   command = "node scripts/build-cinematic-site.mjs"
 ```
 
-The build script uses:
+Primary source/publish relationship:
 
 ```text
-static/html/index1.html  ->  public/index.html
-static/css/**            ->  public/css/**
-static/js/**             ->  public/js/**
-static/images/**         ->  public/images/**
+static/html/index1.html                -> public/index.html
+static/html/pages/products.html        -> public/products/index.html
+static/html/pages/design.html          -> public/design/index.html
+static/css/**                          -> public/css/**
+static/js/**                           -> public/js/**
+static/images/**                       -> public/images/**
 ```
 
-## Active source files
+`static/html/**` is a source tree. It is **not** copied wholesale into `public/html/**`; this prevents legacy page shells from surviving in a deployment.
+
+## PADIEM public information architecture
+
+The site intentionally uses different navigation grammars for different kinds of content.
 
 ```text
-static/html/index1.html          # main cinematic homepage source
-static/css/padiem-cinematic-*.css
-static/js/padiem-cinematic-*.js
-static/images/**
-scripts/build-cinematic-site.mjs
-netlify.toml
-robots.txt
-sitemap.xml
-googlef7d3aa2eaecfa367.html
-naver973c7ccb11cec92fb48885106f1bf365.html
+HOME SCROLL NARRATIVE
+Hero -> Solutions -> Evolution
+
+PRIMARY CINEMATIC DESTINATIONS
+Products -> /products/
+Design   -> /design/
+
+SIDE INFORMATION DRAWER
+Company -> Company / Team / Contact
+
+EXTERNAL PRODUCT ENTRY
+Padiem Chat -> https://chat.padiem.net
 ```
+
+Core rule for Products and Design:
+
+```text
+route changed
+world did not change
+```
+
+They are independent URLs, but they must stay inside the same visual world as the PADIEM first screen.
+
+Recommended global navigation:
+
+```text
+PADIEM   Solutions   Evolution   Products   Design   Company      KO / EN   [Padiem Chat]
+```
+
+The PADIEM logo is the Home control.
+
+## Visual authority
+
+The current cinematic first screen is the primary public visual authority.
+
+Implementation/design contract:
+
+```text
+docs/PADIEM_VISUAL_GRAMMAR_V1.md
+```
+
+Guiding issue:
+
+```text
+GitHub Issue #10
+PADIEM homepage identity system — product, design, and company character alignment
+```
+
+Do not introduce a new generic AI/SaaS template merely because a new page is added.
+
+Canonical visual language includes:
+
+- dark navy-black / graphite field;
+- pearl/frosted glass;
+- white/silver editorial typography;
+- restrained PADIEM blue and warm-gold signals;
+- large negative space;
+- thin technical rules and mono notation;
+- cinematic media composition;
+- restrained motion;
+- content/interaction structure before decorative UI chrome.
+
+## Primary public content
+
+### Products
+
+Current public product set:
+
+- Padiem Chat
+- StoryMemory
+- LoveTree
+- 단지온
+- AI 무료 레이더 (preparing/secondary)
+
+Padiem Chat is the approved live external CTA:
+
+```text
+https://chat.padiem.net
+```
+
+Do not restore the Workers origin URL as a public homepage CTA.
+
+### Design
+
+The Design world is an interaction-structure archive, not a generic agency portfolio.
+
+Current archive candidates include:
+
+- 사람별 기억책장
+- LP 플레이어
+- 메모리테이프
+- 인피니트 비디오월
+- 3D 기억책장
+- 로테이팅 메모리 인덱스
+- 모먼트 리빌
+
+## Design evidence policy
+
+Before major visual changes, review the relevant PADIEM / Padiem Chat / StoryMemory / LoveTree evidence in Google Drive and record what was actually used.
+
+Do not expose private Drive paths, local paths, credentials, raw internal task IDs, or unfinished source URLs in the public site.
+
+## Media policy
+
+Product/design media should come from an approved streaming/publication source such as YouTube or another approved host.
+
+Do not commit large MP4/MOV/WebM binaries unless explicitly approved.
+
+When public media does not exist, use a designed safe placeholder rather than inventing an external product URL.
 
 ## Deployment
 
@@ -47,17 +151,13 @@ GitHub push
 -> padiem.net
 ```
 
-## Legacy Hugo cleanup
+Production changes require preview/build verification before merge.
 
-The earlier Hugo/PaperMod experiment has been moved out of the repository root to avoid confusing future work.
+## Legacy cleanup
 
-Archived location:
+The earlier Hugo/PaperMod experiment is archival only.
 
-```text
-backup/hugo-legacy-20260902/
-```
-
-Archived items:
+Do not restore these as homepage authority:
 
 ```text
 config.toml
@@ -67,25 +167,13 @@ themes/
 .gitmodules
 ```
 
-Do not use `content/products`, `content/design`, or `config.toml` for the current live homepage.
+Do not use the legacy `PadiemAI` blue header, generic card-wall layout, or old standalone About/Contact template as forward design authority.
 
-## Planned homepage direction
+## Source-of-truth policy
 
-The current live site is a cinematic single-page PADIEM homepage. New public work should extend that surface, not revive the Hugo blog structure.
-
-Recommended next sections:
-
-```text
-Products  # product demo video showroom
-Design    # design/showreel video album
-```
-
-Product and design media should be embedded from YouTube or another streaming host. Do not commit large MP4 files directly into this repository unless explicitly approved.
-
-## Source of truth policy
-
-- GitHub is the durable code ledger.
-- Google Drive synced folder is an indirect local sync surface.
-- The current live homepage source is `static/html/index1.html`.
-- `public/` is generated output for Netlify publish.
-- Legacy Hugo files are archival only.
+- GitHub = durable code ledger and public-site implementation authority.
+- Google Drive = design/media evidence authority where applicable.
+- `ai-revenue-lab` = PADIEM product/source authority for actual products and shared technology boundaries.
+- `static/html/index1.html` = canonical home source.
+- `public/` = generated Netlify publish output.
+- Issue #10 + `docs/PADIEM_VISUAL_GRAMMAR_V1.md` = current homepage identity/design contract.

--- a/docs/PADIEM_SCROLL_SCRUB_CONTRACT_V1.md
+++ b/docs/PADIEM_SCROLL_SCRUB_CONTRACT_V1.md
@@ -1,0 +1,93 @@
+# PADIEM Scroll-Scrub Interaction Contract v1
+
+Authority issue: #10
+
+## Why this exists
+
+PADIEM's cinematic identity is not only a palette, typography system, or frosted-glass treatment.
+The homepage uses scroll as a timeline controller: the visitor moves through the page and the fixed background visual advances with that movement.
+
+This is a core interaction rule.
+
+```text
+scroll position
+→ normalized progress
+→ smoothed cinematic timeline
+→ background video currentTime
+→ foreground scene change
+```
+
+The visitor should feel that they are advancing through one continuous PADIEM scene, not scrolling past static cards.
+
+## Canonical behavior
+
+Home already implements this principle with a fixed full-viewport video layer and scroll-linked seeking.
+Products and Design must preserve the same interaction grammar.
+
+Required:
+
+- fixed full-viewport cinematic background layer;
+- background media remains behind foreground copy and scene structures;
+- vertical scroll drives media timeline rather than autonomous playback;
+- seeking is smoothed so the background does not jitter on wheel/touch input;
+- progress line and background timeline derive from the same page-scroll progress;
+- foreground sections may be full-height scenes, but must not become independent generic cards;
+- if media fails, a dark PADIEM atmospheric poster/gradient remains as fallback;
+- `prefers-reduced-motion` disables the moving video surface and keeps a static fallback;
+- large video binaries are not committed to this repository.
+
+## Public worlds
+
+```text
+/           Home cinematic narrative
+/products/ Products cinematic world
+/design/   Design cinematic world
+```
+
+All three should feel like one brand environment.
+
+Rule:
+
+```text
+route changed
+world did not change
+```
+
+## Current media policy
+
+Until a dedicated approved Products or Design background sequence exists, the approved homepage cinematic video may be reused as the shared corporate scroll-scrub background.
+
+Per-world media can later override the default through:
+
+```html
+<body data-world-scroll-video="https://approved-media.example/video.mp4">
+```
+
+The interaction engine must remain the same even when the media source changes.
+
+## Runtime
+
+Shared runtime:
+
+```text
+static/js/padiem-scroll-scrub-v1.js
+```
+
+Canonical build injects this runtime into Products and Design outputs.
+
+## QA
+
+A Products/Design PR is not visually complete unless the following pass:
+
+```text
+SCROLL_SCRUB_BACKGROUND = PASS
+BACKGROUND_FIXED = PASS
+SCROLL_DRIVES_VIDEO_TIME = PASS
+AUTOPLAY_INDEPENDENT_OF_SCROLL = NO
+FOREGROUND_READABILITY = PASS
+MOBILE_SCROLL = PASS
+REDUCED_MOTION_FALLBACK = PASS
+MEDIA_FAILURE_FALLBACK = PASS
+```
+
+A static gradient-only background may be used only as failure/reduced-motion fallback, not as the normal final interaction surface.

--- a/docs/PADIEM_VISUAL_GRAMMAR_V1.md
+++ b/docs/PADIEM_VISUAL_GRAMMAR_V1.md
@@ -1,0 +1,263 @@
+# PADIEM Visual Grammar v1
+
+Status: implementation authority for Issue #10
+
+## 1. Canonical visual authority
+
+The current `padiem.net` cinematic first screen is the primary public visual authority.
+
+Do not treat the existing `/products/`, `/design/`, `/about/`, or `/contact/` legacy page shell as design authority.
+
+The public identity must preserve the first-screen grammar:
+
+- dark navy-black / graphite field around `#06080d`;
+- pearl/frosted glass, not generic flat cards;
+- white / silver primary typography;
+- restrained PADIEM blue signal around `#88c9ff`;
+- restrained warm-gold signal around `#efc984`;
+- SUIT/SUITE + Manrope family;
+- large editorial Korean typography;
+- small mono/technical notation;
+- thin translucent rules;
+- large negative space;
+- cinematic media as part of the composition;
+- quiet, restrained motion.
+
+The goal is not merely to copy colors. The composition and interaction hierarchy must remain recognizably PADIEM.
+
+## 2. Evidence from existing PADIEM design work
+
+### B62 Padiem Chat cinematic QA
+
+The accepted continuity review records:
+
+- homepage -> Padiem Chat brand continuity;
+- `#06080d` dark cinematic field;
+- pearl glass;
+- `#88c9ff` blue signal;
+- `#efc984` warm gold;
+- editorial typography;
+- thin translucent rules;
+- restrained motion;
+- explicit rejection of generic AI SaaS visual language.
+
+This means the homepage is not an isolated marketing skin. It is already acting as a first-party PADIEM product-language authority.
+
+### LoveTree / Memory Tape work
+
+The Memory Tape design work establishes another PADIEM-family principle:
+
+> interaction metaphor must be structurally credible, not merely decorated to resemble the metaphor.
+
+The accepted direction is `MECHANICS FIRST -> VISUAL FIDELITY -> CONTENT`.
+
+For homepage work this translates to:
+
+- do not fake “cinematic” with gradients alone;
+- layout, scrolling, depth and transition must support the concept;
+- Products and Design should behave like exhibition scenes, not legacy cards with a cinematic background pasted behind them.
+
+### LoveTree editorial archive work
+
+The editorial archive work establishes:
+
+- content should appear before UI chrome;
+- native media ratio matters;
+- different content deserves different scale;
+- large and small surfaces should create editorial rhythm;
+- negative space is active structure;
+- avoid forcing every item into the same card frame;
+- many-at-a-glance views can still be curated rather than dashboard-like.
+
+For `padiem.net`, this means Products/Design scenes may use full-bleed media, asymmetric editorial layouts and different scene structures instead of repeated identical card rows.
+
+## 3. Site information architecture
+
+PADIEM uses three internal navigation grammars plus one external product exit.
+
+### A. Home scroll narrative
+
+```text
+Hero
+  -> Solutions
+  -> Evolution
+```
+
+These remain a continuous vertical cinematic narrative on `/`.
+
+### B. Primary cinematic destinations
+
+```text
+Products -> /products/
+Design   -> /design/
+```
+
+These are independent URLs because they are expandable content worlds.
+
+However:
+
+```text
+route changed
+world did not change
+```
+
+The header, atmosphere, typography, signals, spacing and motion must remain in the same PADIEM visual world.
+
+### C. Side information drawer
+
+```text
+Company
+  -> Company
+  -> Team
+  -> Contact
+```
+
+Company/Team/Contact are information surfaces, not primary exhibition worlds. They should use the existing right-side pearl/frosted drawer language rather than navigate into generic standalone pages.
+
+Direct `/about/` and `/contact/` URLs may remain for compatibility/SEO, but they are not primary visual-navigation authority and should eventually resolve into or faithfully reproduce the drawer experience.
+
+### D. External product entry
+
+```text
+Padiem Chat -> https://chat.padiem.net
+```
+
+The public homepage must not revert to the Workers origin URL.
+
+## 4. Global navigation contract
+
+Recommended desktop navigation:
+
+```text
+PADIEM   Solutions   Evolution   Products   Design   Company        KO / EN   [Padiem Chat]
+```
+
+Rules:
+
+- PADIEM logo -> `/`;
+- Solutions -> `/#solutions`;
+- Evolution -> `/#evolution`;
+- Products -> `/products/`;
+- Design -> `/design/`;
+- Company -> right drawer;
+- Padiem Chat -> `https://chat.padiem.net`;
+- no separate Home label is required when the logo already owns Home;
+- do not mix “About means page on one route, drawer on another”.
+
+## 5. Products world
+
+Products must be a cinematic exhibition, not a repeating left-right showcase template.
+
+Primary public set:
+
+1. Padiem Chat
+2. StoryMemory
+3. LoveTree
+4. 단지온
+5. AI 무료 레이더 (secondary / preparing)
+
+Scene principle:
+
+```text
+one product = one authored scene
+```
+
+Each scene should combine:
+
+- small technical index (`PRODUCT / 01`);
+- a large editorial product statement;
+- a media field or safe media placeholder;
+- restrained status metadata;
+- short, concrete product meaning;
+- CTA only when the destination is public and approved.
+
+Padiem Chat remains the clear live CTA.
+
+Do not expose unfinished product URLs.
+
+## 6. Design world
+
+Design is not an agency portfolio. It is evidence of how PADIEM invents interaction structures.
+
+Primary archive candidates:
+
+- 사람별 기억책장
+- LP 플레이어
+- 메모리테이프
+- 인피니트 비디오월
+- 3D 기억책장
+- 로테이팅 메모리 인덱스
+- 모먼트 리빌
+
+Each scene should answer:
+
+1. What human memory/workflow/emotion is being organized?
+2. What is the interaction metaphor?
+3. What makes the structure specifically PADIEM-like?
+
+Do not reduce these to a generic feature list.
+
+Use varying scene scales, native media proportions and editorial rhythm where real media becomes available.
+
+## 7. Company drawer
+
+The right-side drawer is a first-party PADIEM pattern and should be retained/refined.
+
+The Company surface should expose three internal destinations:
+
+```text
+01 COMPANY
+02 TEAM
+03 CONTACT
+```
+
+The current pearl panel language is appropriate:
+
+- translucent pale surface;
+- heavy blur;
+- asymmetric rounded shape;
+- strong dark/light contrast against the cinematic scene;
+- no full-site context loss.
+
+## 8. Explicit rejects
+
+Do not use as the forward design system:
+
+- legacy `PadiemAI` blue logo/header;
+- generic blue SaaS navigation;
+- identical card walls;
+- alternating image-left/text-right template rows as the dominant page grammar;
+- startup-template statistics or unverified claims;
+- unrelated stock imagery;
+- large MP4 binaries committed into the repository;
+- generic About/Contact template pages as primary navigation destinations;
+- restoring Hugo/PaperMod.
+
+## 9. Implementation order
+
+```text
+1. lock Visual Grammar
+2. unify global cinematic shell/navigation
+3. rebuild Products as cinematic scenes
+4. rebuild Design as cinematic exhibition scenes
+5. refine Company drawer -> Company / Team / Contact
+6. reconcile direct About/Contact URLs
+7. add real media from approved YouTube/streaming sources
+8. browser visual QA
+9. production rollout
+```
+
+## 10. Acceptance
+
+```text
+HOME_CANONICAL_VISUAL_AUTHORITY = YES
+GLOBAL_NAVIGATION_GRAMMAR = CONSISTENT
+PRODUCTS = CINEMATIC_WORLD
+DESIGN = CINEMATIC_WORLD
+COMPANY_TEAM_CONTACT = SIDE_DRAWER
+PADIEM_CHAT_PUBLIC_URL = https://chat.padiem.net
+GENERIC_PADIEMAI_SHELL = NOT_AUTHORITY
+CARD_WALL_AS_PRIMARY_GRAMMAR = NO
+DRIVE_DESIGN_EVIDENCE_REVIEWED = YES
+VISUAL_OWNER_REVIEW_REQUIRED = YES
+```

--- a/scripts/build-cinematic-site.mjs
+++ b/scripts/build-cinematic-site.mjs
@@ -82,12 +82,12 @@ for (const [source, destination] of requiredFiles) {
   copyFileSync(source, destination);
 }
 
-// Publish standalone cinematic worlds to clean root-level URLs.
+// Publish only the primary cinematic destinations. Company / Team / Contact
+// remain first-party drawer surfaces inside the home world and are reached via
+// compatibility redirects; do not republish the legacy standalone page shell.
 const showcasePages = [
   { source: "pages/products.html", dest: "products/index.html" },
   { source: "pages/design.html",  dest: "design/index.html"  },
-  { source: "pages/about.html",   dest: "about/index.html"   },
-  { source: "pages/contact.html", dest: "contact/index.html" },
 ];
 
 for (const { source, dest } of showcasePages) {

--- a/scripts/build-cinematic-site.mjs
+++ b/scripts/build-cinematic-site.mjs
@@ -23,6 +23,8 @@ let html = readFileSync(sourceHtml, "utf8");
 const oldTitle = "<title>PADIEM Cinematic Pearl Glass Demo V2</title>";
 const newTitle = "<title>PADIEM | AI로 일을 다시 설계합니다</title>";
 const languageScript = '<script src="/js/padiem-cinematic-v2-2.js"></script>';
+const homeNavScript = '<script src="/js/padiem-home-nav-v1.js"></script>';
+const drawerTabsScript = '<script src="/js/padiem-home-drawer-tabs-v1.js"></script>';
 
 if (!html.includes(oldTitle)) {
   throw new Error("Expected cinematic source title was not found; refusing to publish an unreviewed head change.");
@@ -46,6 +48,15 @@ const seoHead = [
 ].join("");
 
 html = html.replace(oldTitle, seoHead);
+
+// The legacy source markup still contains the previous navigation labels. Inject
+// the IA adapter before the existing language/overlay runtime so that the latter
+// binds to the final navigation semantics. The drawer-tab enhancer runs after it.
+html = html.replace(
+  languageScript,
+  `${homeNavScript}${languageScript}${drawerTabsScript}`,
+);
+
 writeFileSync(join(publicDir, "index.html"), html, "utf8");
 
 // Copy supporting directories.
@@ -71,7 +82,7 @@ for (const [source, destination] of requiredFiles) {
   copyFileSync(source, destination);
 }
 
-// Publish standalone showcase pages to clean root-level URLs.
+// Publish standalone cinematic worlds to clean root-level URLs.
 const showcasePages = [
   { source: "pages/products.html", dest: "products/index.html" },
   { source: "pages/design.html",  dest: "design/index.html"  },
@@ -100,4 +111,4 @@ for (const file of [
   }
 }
 
-console.log("Built canonical single-page PADIEM cinematic site.");
+console.log("Built canonical PADIEM cinematic site and worlds.");

--- a/scripts/build-cinematic-site.mjs
+++ b/scripts/build-cinematic-site.mjs
@@ -59,8 +59,9 @@ html = html.replace(
 
 writeFileSync(join(publicDir, "index.html"), html, "utf8");
 
-// Copy supporting directories.
-for (const dir of ["css", "js", "images", "html"]) {
+// Copy only runtime assets. Do NOT copy static/html/** wholesale: that tree still
+// contains archived/legacy page shells which must never reappear in production.
+for (const dir of ["css", "js", "images"]) {
   const source = join(root, "static", dir);
   if (!existsSync(source)) {
     throw new Error(`Required asset directory is missing: static/${dir}`);
@@ -100,7 +101,7 @@ for (const { source, dest } of showcasePages) {
   copyFileSync(srcPath, destPath);
 }
 
-// Preserve legacy search-engine verification files without republishing the old site.
+// Preserve search-engine verification files without republishing the old site.
 for (const file of [
   "googlef7d3aa2eaecfa367.html",
   "naver973c7ccb11cec92fb48885106f1bf365.html",

--- a/scripts/build-cinematic-site.mjs
+++ b/scripts/build-cinematic-site.mjs
@@ -25,6 +25,7 @@ const newTitle = "<title>PADIEM | AI로 일을 다시 설계합니다</title>";
 const languageScript = '<script src="/js/padiem-cinematic-v2-2.js"></script>';
 const homeNavScript = '<script src="/js/padiem-home-nav-v1.js"></script>';
 const drawerTabsScript = '<script src="/js/padiem-home-drawer-tabs-v1.js"></script>';
+const worldScrubScript = '<script src="/js/padiem-scroll-scrub-v1.js"></script>';
 
 if (!html.includes(oldTitle)) {
   throw new Error("Expected cinematic source title was not found; refusing to publish an unreviewed head change.");
@@ -96,9 +97,21 @@ for (const { source, dest } of showcasePages) {
   if (!existsSync(srcPath)) {
     throw new Error(`Showcase page is missing: static/html/${source}`);
   }
+
+  let pageHtml = readFileSync(srcPath, "utf8");
+  if (!pageHtml.includes('padiem-cinematic-worlds-v1.js')) {
+    throw new Error(`Cinematic world runtime is missing from static/html/${source}`);
+  }
+  if (!pageHtml.includes('</body>')) {
+    throw new Error(`Expected </body> was not found in static/html/${source}`);
+  }
+  if (!pageHtml.includes('padiem-scroll-scrub-v1.js')) {
+    pageHtml = pageHtml.replace('</body>', `  ${worldScrubScript}\n</body>`);
+  }
+
   const destPath = join(publicDir, dest);
   mkdirSync(join(publicDir, dest.split("/")[0]), { recursive: true });
-  copyFileSync(srcPath, destPath);
+  writeFileSync(destPath, pageHtml, "utf8");
 }
 
 // Preserve search-engine verification files without republishing the old site.

--- a/scripts/build-cinematic-site.mjs
+++ b/scripts/build-cinematic-site.mjs
@@ -26,6 +26,7 @@ const languageScript = '<script src="/js/padiem-cinematic-v2-2.js"></script>';
 const homeNavScript = '<script src="/js/padiem-home-nav-v1.js"></script>';
 const drawerTabsScript = '<script src="/js/padiem-home-drawer-tabs-v1.js"></script>';
 const worldScrubScript = '<script src="/js/padiem-scroll-scrub-v1.js"></script>';
+const homeMobileNavStyle = '<link rel="stylesheet" href="/css/padiem-home-mobile-nav-v1.css"/>';
 
 if (!html.includes(oldTitle)) {
   throw new Error("Expected cinematic source title was not found; refusing to publish an unreviewed head change.");
@@ -35,6 +36,9 @@ if (html.includes('rel="canonical"')) {
 }
 if (!html.includes(languageScript)) {
   throw new Error("Expected language runtime script was not found; refusing to publish without the KO/EN language runtime.");
+}
+if (!html.includes('</head>')) {
+  throw new Error("Expected </head> was not found in cinematic source.");
 }
 
 const seoHead = [
@@ -49,6 +53,10 @@ const seoHead = [
 ].join("");
 
 html = html.replace(oldTitle, seoHead);
+
+if (!html.includes('padiem-home-mobile-nav-v1.css')) {
+  html = html.replace('</head>', `${homeMobileNavStyle}</head>`);
+}
 
 // The legacy source markup still contains the previous navigation labels. Inject
 // the IA adapter before the existing language/overlay runtime so that the latter

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,8 +2,20 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://padiem.net/</loc>
-    <lastmod>2026-08-25</lastmod>
+    <lastmod>2026-09-02</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://padiem.net/products/</loc>
+    <lastmod>2026-09-02</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://padiem.net/design/</loc>
+    <lastmod>2026-09-02</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
   </url>
 </urlset>

--- a/static/_redirects
+++ b/static/_redirects
@@ -6,29 +6,35 @@
 /html/index1.html                /            301!
 /html/index.html                 /            301!
 
-# Canonicalize Products / Design sub-paths to clean URLs.
+# Canonicalize Products / Design sub-paths to clean cinematic-world URLs.
 /products/index.html             /products/   301!
 /products.html                   /products/   301!
 /design/index.html               /design/     301!
 /design.html                     /design/     301!
-/about/index.html                /about/      301!
-/contact/index.html              /contact/    301!
 
-# Legacy company/team/contact content is consolidated into the current homepage overlays.
-/html/pages/about/company        /            301!
-/html/pages/about/company.html   /            301!
-/html/pages/about/team           /            301!
-/html/pages/about/team.html      /            301!
-/html/pages/about/contact        /            301!
-/html/pages/about/contact.html   /            301!
+# Company / Team / Contact are information drawers inside the canonical home world.
+# Keep these redirects temporary (302) until the owner accepts the new drawer IA in production.
+/about/index.html                /?panel=company 302!
+/about/                          /?panel=company 302!
+/team/                           /?panel=team    302!
+/contact/index.html              /?panel=contact 302!
+/contact/                        /?panel=contact 302!
+
+# Legacy company/team/contact content is consolidated into the current homepage drawer system.
+/html/pages/about/company        /?panel=company 301!
+/html/pages/about/company.html   /?panel=company 301!
+/html/pages/about/team           /?panel=team    301!
+/html/pages/about/team.html      /?panel=team    301!
+/html/pages/about/contact        /?panel=contact 301!
+/html/pages/about/contact.html   /?panel=contact 301!
 
 # Legacy technology/service content is consolidated into the current Solutions section.
-/html/pages/ai-tech/*            /            301!
-/html/pages/services/*           /            301!
-/html/pages/education/*          /            301!
-/html/pages/success/*            /            301!
-/html/pages/about/careers        /            301!
-/html/pages/about/careers.html   /            301!
+/html/pages/ai-tech/*            /#solutions     301!
+/html/pages/services/*           /#solutions     301!
+/html/pages/education/*          /#solutions     301!
+/html/pages/success/*            /#evolution     301!
+/html/pages/about/careers        /?panel=company 301!
+/html/pages/about/careers.html   /?panel=company 301!
 
 # Removed legacy pages have no current equivalent; return a real 404 rather than a soft-404 redirect.
 /html/pages/*                    /404.html    404!

--- a/static/css/padiem-cinematic-worlds-v1.css
+++ b/static/css/padiem-cinematic-worlds-v1.css
@@ -1,0 +1,235 @@
+/* PADIEM cinematic world system
+   Authority: docs/PADIEM_VISUAL_GRAMMAR_V1.md + Issue #10 */
+
+body.world-body {
+  --world-ink: #f5f7fa;
+  --world-muted: rgba(245,247,250,.62);
+  --world-faint: rgba(245,247,250,.34);
+  --world-line: rgba(255,255,255,.13);
+  --world-blue: #88c9ff;
+  --world-gold: #efc984;
+  background:#06080d;
+  color:var(--world-ink);
+}
+
+body.world-body::before {
+  content:"";
+  position:fixed;
+  inset:0;
+  z-index:0;
+  pointer-events:none;
+  background:
+    radial-gradient(circle at 72% 20%, rgba(136,201,255,.11), transparent 27%),
+    radial-gradient(circle at 22% 68%, rgba(239,201,132,.075), transparent 28%),
+    linear-gradient(145deg,#07101a 0%,#07090e 50%,#020305 100%);
+}
+
+body.world-body::after {
+  content:"";
+  position:fixed;
+  inset:0;
+  z-index:0;
+  pointer-events:none;
+  opacity:.42;
+  background-image:
+    linear-gradient(rgba(255,255,255,.018) 1px, transparent 1px),
+    linear-gradient(90deg,rgba(255,255,255,.018) 1px, transparent 1px);
+  background-size:72px 72px;
+  mask-image:linear-gradient(to bottom,rgba(0,0,0,.9),transparent 76%);
+}
+
+.world-page { position:relative; z-index:10; }
+
+.world-nav .nav-link[aria-current="page"] {
+  color:#fff;
+  position:relative;
+}
+.world-nav .nav-link[aria-current="page"]::after {
+  content:"";
+  position:absolute;
+  left:0;
+  right:0;
+  bottom:-11px;
+  height:1px;
+  background:linear-gradient(90deg,var(--world-blue),rgba(255,255,255,.8),var(--world-gold));
+}
+.world-nav-tools { display:flex; align-items:center; gap:14px; }
+.world-lang { display:flex; align-items:center; gap:5px; font-family:var(--font-label); font-size:10px; letter-spacing:.08em; }
+.world-lang button { appearance:none; border:0; background:none; padding:5px 2px; color:rgba(255,255,255,.42); cursor:pointer; font:inherit; letter-spacing:inherit; }
+.world-lang button[aria-pressed="true"], .world-lang button:hover { color:#fff; }
+.world-lang span { color:rgba(255,255,255,.22); }
+
+.world-hero,
+.world-scene {
+  position:relative;
+  min-height:100vh;
+  min-height:100svh;
+  padding:112px var(--pad) 54px;
+  border-bottom:1px solid rgba(255,255,255,.07);
+  overflow:hidden;
+}
+
+.world-hero { display:flex; flex-direction:column; justify-content:space-between; }
+.world-hero-top { display:flex; justify-content:space-between; gap:36px; align-items:flex-start; }
+.world-hero-index { display:flex; flex-direction:column; gap:9px; }
+.world-overline { font-family:var(--font-label); text-transform:uppercase; letter-spacing:.18em; font-size:10px; color:rgba(255,255,255,.68); }
+.world-overline strong { color:#fff; font-weight:600; }
+.world-hero-note { max-width:440px; text-align:right; color:rgba(255,255,255,.8); font-size:16px; line-height:1.72; letter-spacing:-.022em; word-break:keep-all; }
+.world-hero-bottom { display:grid; grid-template-columns:minmax(0,1.3fr) minmax(290px,.7fr); gap:clamp(42px,8vw,120px); align-items:end; }
+.world-display { font-family:var(--font-display); font-size:clamp(64px,9.1vw,138px); line-height:.89; letter-spacing:-.075em; font-weight:var(--display-weight); text-wrap:balance; text-shadow:0 18px 46px rgba(0,0,0,.44); }
+.world-display .ghost { display:block; color:rgba(255,255,255,.33); padding-left:clamp(0px,5vw,72px); }
+.world-hero-ledger { border-left:1px solid rgba(255,255,255,.32); padding:6px 0 6px 24px; }
+.world-hero-ledger dl { margin:0; display:grid; gap:16px; }
+.world-hero-ledger div { display:grid; grid-template-columns:74px 1fr; gap:16px; }
+.world-hero-ledger dt { font-family:var(--font-label); text-transform:uppercase; letter-spacing:.15em; font-size:9px; color:rgba(255,255,255,.35); }
+.world-hero-ledger dd { margin:0; font-size:12px; line-height:1.55; color:rgba(255,255,255,.72); }
+
+.world-scene { display:grid; grid-template-rows:auto 1fr auto; gap:30px; }
+.world-scene::before {
+  content:"";
+  position:absolute;
+  inset:11% 5% 8% 31%;
+  border:1px solid rgba(255,255,255,.08);
+  border-radius:42% 22% 34% 18% / 34% 28% 42% 26%;
+  background:
+    radial-gradient(circle at 35% 42%, rgba(var(--scene-rgb,136,201,255),.15), transparent 23%),
+    radial-gradient(circle at 70% 62%, rgba(239,201,132,.075), transparent 24%),
+    linear-gradient(135deg,rgba(255,255,255,.025),rgba(255,255,255,.006));
+  box-shadow:0 80px 160px rgba(0,0,0,.22), inset 0 1px rgba(255,255,255,.06);
+  transform:rotate(-2.5deg);
+  pointer-events:none;
+}
+.world-scene:nth-of-type(even)::before { inset:10% 28% 7% 4%; transform:rotate(2.2deg); }
+.world-scene-head { position:relative; z-index:2; display:flex; align-items:center; justify-content:space-between; gap:24px; }
+.world-scene-code { display:flex; align-items:center; gap:14px; font-family:var(--font-label); text-transform:uppercase; letter-spacing:.17em; font-size:9px; color:rgba(255,255,255,.48); }
+.world-scene-code::before { content:""; width:44px; height:1px; background:linear-gradient(90deg,rgb(var(--scene-rgb,136,201,255)),rgba(255,255,255,.12)); }
+.world-scene-status { display:inline-flex; align-items:center; gap:8px; font-family:var(--font-label); text-transform:uppercase; letter-spacing:.12em; font-size:9px; color:rgba(255,255,255,.54); }
+.world-scene-status i { width:6px; height:6px; border-radius:50%; background:rgb(var(--scene-rgb,136,201,255)); box-shadow:0 0 14px rgba(var(--scene-rgb,136,201,255),.68); }
+
+.world-scene-body { position:relative; z-index:2; display:grid; grid-template-columns:minmax(0,.78fr) minmax(380px,1.22fr); gap:clamp(42px,7vw,110px); align-items:center; }
+.world-scene:nth-of-type(even) .world-scene-body { grid-template-columns:minmax(380px,1.18fr) minmax(0,.82fr); }
+.world-scene:nth-of-type(even) .world-copy { order:2; }
+.world-scene:nth-of-type(even) .world-media { order:1; }
+.world-copy { align-self:end; padding-bottom:clamp(20px,4vw,58px); }
+.world-kicker { margin-bottom:18px; font-family:var(--font-label); font-size:10px; text-transform:uppercase; letter-spacing:.18em; color:rgba(255,255,255,.48); }
+.world-title { max-width:720px; font-family:var(--font-display); font-size:clamp(48px,6.8vw,104px); line-height:.95; letter-spacing:-.067em; font-weight:var(--display-weight); text-wrap:balance; word-break:keep-all; }
+.world-title .quiet { color:rgba(255,255,255,.34); }
+.world-summary { margin-top:28px; max-width:520px; font-size:15px; line-height:1.82; letter-spacing:-.02em; color:rgba(255,255,255,.68); word-break:keep-all; }
+.world-actions { margin-top:28px; display:flex; flex-wrap:wrap; gap:10px; }
+.world-action-primary { display:inline-flex; align-items:center; gap:8px; padding:11px 18px; border-radius:999px; background:#fff; color:#05070b; font-size:12px; font-weight:650; }
+.world-action-secondary { display:inline-flex; align-items:center; padding:10px 17px; border:1px solid rgba(255,255,255,.2); border-radius:999px; background:rgba(255,255,255,.065); backdrop-filter:blur(16px); color:rgba(255,255,255,.72); font-size:11px; }
+
+.world-media { position:relative; min-height:clamp(350px,53vh,620px); }
+.world-media-frame {
+  position:absolute;
+  inset:0;
+  overflow:hidden;
+  border:1px solid rgba(255,255,255,.16);
+  border-radius:32px 10px 32px 10px;
+  background:
+    radial-gradient(circle at 66% 34%, rgba(var(--scene-rgb,136,201,255),.18), transparent 23%),
+    radial-gradient(circle at 34% 74%, rgba(239,201,132,.09), transparent 27%),
+    linear-gradient(145deg,rgba(255,255,255,.075),rgba(255,255,255,.015) 46%,rgba(0,0,0,.17));
+  backdrop-filter:blur(20px);
+  box-shadow:0 40px 100px rgba(0,0,0,.3), inset 0 1px rgba(255,255,255,.1);
+}
+.world-media-frame::before {
+  content:"";
+  position:absolute;
+  width:72%;
+  aspect-ratio:1;
+  border:1px solid rgba(255,255,255,.12);
+  border-radius:50%;
+  left:38%;
+  top:-16%;
+  box-shadow:0 0 0 42px rgba(255,255,255,.012),0 0 0 108px rgba(255,255,255,.008);
+}
+.world-media-frame::after {
+  content:"";
+  position:absolute;
+  left:6%;
+  right:6%;
+  bottom:12%;
+  height:1px;
+  background:linear-gradient(90deg,transparent,rgb(var(--scene-rgb,136,201,255)),rgba(255,255,255,.5),rgba(239,201,132,.7),transparent);
+  opacity:.7;
+}
+.world-media-label { position:absolute; top:22px; left:24px; z-index:2; font-family:var(--font-label); text-transform:uppercase; letter-spacing:.17em; font-size:9px; color:rgba(255,255,255,.55); }
+.world-media-message { position:absolute; left:24px; right:24px; bottom:24px; z-index:2; display:flex; align-items:flex-end; justify-content:space-between; gap:20px; }
+.world-media-message strong { max-width:330px; font-family:var(--font-display); font-size:clamp(22px,2.5vw,38px); line-height:1.05; letter-spacing:-.045em; font-weight:520; }
+.world-media-message span { font-family:var(--font-label); text-transform:uppercase; letter-spacing:.13em; font-size:8px; color:rgba(255,255,255,.4); }
+
+.world-scene-foot { position:relative; z-index:2; display:grid; grid-template-columns:1fr auto; gap:24px; align-items:end; border-top:1px solid rgba(255,255,255,.12); padding-top:18px; }
+.world-tags { display:flex; flex-wrap:wrap; gap:7px; }
+.world-tags span { padding:6px 9px; border:1px solid rgba(255,255,255,.12); border-radius:999px; font-family:var(--font-label); text-transform:uppercase; letter-spacing:.1em; font-size:8px; color:rgba(255,255,255,.48); background:rgba(255,255,255,.03); }
+.world-number { font-family:var(--font-label); font-size:34px; letter-spacing:-.04em; color:rgba(255,255,255,.18); }
+
+.world-archive-intro { min-height:78svh; padding-top:128px; }
+.world-archive-grid { position:relative; z-index:2; display:grid; grid-template-columns:repeat(12,minmax(0,1fr)); gap:18px; margin-top:46px; }
+.world-archive-tile { min-height:230px; padding:22px; border-top:1px solid rgba(255,255,255,.18); background:linear-gradient(180deg,rgba(255,255,255,.055),rgba(255,255,255,.012)); backdrop-filter:blur(14px); display:flex; flex-direction:column; justify-content:space-between; overflow:hidden; }
+.world-archive-tile.feature { grid-column:span 7; min-height:430px; }
+.world-archive-tile.medium { grid-column:span 5; min-height:330px; }
+.world-archive-tile.small { grid-column:span 4; min-height:260px; }
+.world-archive-tile.wide { grid-column:span 8; min-height:300px; }
+.world-archive-tile .tile-index { font-family:var(--font-label); font-size:9px; letter-spacing:.16em; color:rgba(255,255,255,.37); }
+.world-archive-tile h2 { max-width:90%; font-family:var(--font-display); font-size:clamp(30px,4vw,62px); line-height:.96; letter-spacing:-.055em; font-weight:520; word-break:keep-all; }
+.world-archive-tile p { max-width:460px; font-size:13px; line-height:1.7; color:rgba(255,255,255,.58); word-break:keep-all; }
+.world-archive-tile .tile-line { width:72px; height:1px; margin:18px 0; background:linear-gradient(90deg,var(--world-blue),var(--world-gold)); }
+
+.world-drawer-tabs { display:flex; gap:7px; flex-wrap:wrap; margin:0 0 22px; }
+.world-drawer-tabs button { border:1px solid rgba(35,63,86,.16); border-radius:999px; background:rgba(255,255,255,.23); color:rgba(17,42,62,.66); padding:8px 11px; font-family:var(--font-label); font-size:9px; letter-spacing:.12em; cursor:pointer; }
+.world-drawer-tabs button[aria-pressed="true"] { background:#17354e; color:#fff; border-color:#17354e; }
+.world-drawer-copy { color:#1b3a53; }
+.world-drawer-copy h3 { margin:0 0 14px; font-family:var(--font-display); font-size:clamp(25px,3vw,42px); line-height:1; letter-spacing:-.05em; }
+.world-drawer-copy p { margin:0 0 14px; font-size:13px; line-height:1.75; color:rgba(27,58,83,.72); word-break:keep-all; }
+.world-drawer-list { margin:18px 0 0; padding:0; list-style:none; border-top:1px solid rgba(35,63,86,.14); }
+.world-drawer-list li { padding:11px 0; border-bottom:1px solid rgba(35,63,86,.11); font-size:12px; color:#24455f; }
+.world-drawer-link { display:inline-flex; margin-top:12px; border-radius:999px; background:#17354e; color:white; padding:10px 14px; font-size:11px; }
+
+.world-footer { position:relative; z-index:2; padding:28px var(--pad) 34px; display:flex; justify-content:space-between; gap:18px; font-family:var(--font-label); text-transform:uppercase; letter-spacing:.13em; font-size:8px; color:rgba(255,255,255,.36); }
+
+@media (max-width:1100px) {
+  .world-nav .nav-links { gap:16px; }
+  .world-nav .nav-link { font-size:10px; }
+  .world-hero-bottom { grid-template-columns:1fr minmax(240px,.48fr); }
+  .world-scene-body, .world-scene:nth-of-type(even) .world-scene-body { grid-template-columns:1fr 1fr; gap:36px; }
+}
+
+@media (max-width:820px) {
+  .world-nav .nav-inner { height:auto; min-height:72px; padding-top:12px; padding-bottom:12px; flex-wrap:wrap; gap:10px 16px; }
+  .world-nav .nav-links { order:3; width:100%; overflow-x:auto; padding:7px 0 2px; justify-content:flex-start; scrollbar-width:none; }
+  .world-nav .nav-links::-webkit-scrollbar { display:none; }
+  .world-nav-tools { margin-left:auto; }
+  .world-lang { display:none; }
+  .world-hero, .world-scene { padding-top:126px; }
+  .world-hero-top { flex-direction:column; gap:24px; }
+  .world-hero-note { text-align:left; max-width:520px; }
+  .world-hero-bottom { grid-template-columns:1fr; gap:38px; }
+  .world-hero-ledger { max-width:460px; }
+  .world-scene-body, .world-scene:nth-of-type(even) .world-scene-body { grid-template-columns:1fr; }
+  .world-scene:nth-of-type(even) .world-copy, .world-scene:nth-of-type(even) .world-media { order:initial; }
+  .world-copy { padding-bottom:0; }
+  .world-media { min-height:48svh; }
+  .world-scene::before, .world-scene:nth-of-type(even)::before { inset:28% -12% 8% 16%; }
+  .world-archive-tile.feature, .world-archive-tile.medium, .world-archive-tile.small, .world-archive-tile.wide { grid-column:span 12; min-height:300px; }
+}
+
+@media (max-width:560px) {
+  .world-nav .logo { font-size:17px; }
+  .world-nav .logo-mark { width:24px; height:24px; }
+  .world-nav .nav-cta { padding:8px 11px; font-size:11px; }
+  .world-nav .nav-link { white-space:nowrap; }
+  .world-hero, .world-scene { padding-left:18px; padding-right:18px; }
+  .world-display { font-size:clamp(54px,17vw,82px); }
+  .world-title { font-size:clamp(46px,14vw,72px); }
+  .world-media { min-height:410px; }
+  .world-media-frame { border-radius:24px 8px 24px 8px; }
+  .world-scene-foot { grid-template-columns:1fr; }
+  .world-number { display:none; }
+  .world-footer { flex-direction:column; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html { scroll-behavior:auto; }
+  .reveal { opacity:1!important; transform:none!important; transition:none!important; }
+}

--- a/static/css/padiem-home-mobile-nav-v1.css
+++ b/static/css/padiem-home-mobile-nav-v1.css
@@ -1,0 +1,205 @@
+/* PADIEM home mobile navigation
+   Keeps the desktop cinematic IA reachable below 760px without changing
+   the existing desktop rail. The sheet deliberately shares the pearl/glass
+   language of the Company drawer. */
+
+.home-mobile-menu-toggle,
+.home-mobile-menu {
+  display:none;
+}
+
+@media (max-width:760px) {
+  .home-mobile-menu-toggle {
+    appearance:none;
+    display:inline-flex;
+    align-items:center;
+    gap:8px;
+    min-height:34px;
+    padding:7px 10px;
+    border:1px solid rgba(255,255,255,.18);
+    border-radius:999px;
+    background:rgba(5,12,21,.38);
+    backdrop-filter:blur(14px) saturate(1.1);
+    -webkit-backdrop-filter:blur(14px) saturate(1.1);
+    color:rgba(255,255,255,.82);
+    font-family:var(--font-label);
+    font-size:9px;
+    font-weight:600;
+    letter-spacing:.13em;
+    cursor:pointer;
+  }
+
+  .home-mobile-menu-toggle:hover,
+  .home-mobile-menu-toggle[aria-expanded="true"] {
+    color:#fff;
+    border-color:rgba(255,255,255,.38);
+    background:rgba(255,255,255,.11);
+  }
+
+  .home-mobile-menu-toggle-lines {
+    position:relative;
+    width:13px;
+    height:9px;
+  }
+
+  .home-mobile-menu-toggle-lines::before,
+  .home-mobile-menu-toggle-lines::after {
+    content:"";
+    position:absolute;
+    left:0;
+    width:13px;
+    height:1px;
+    background:currentColor;
+    transition:transform .25s ease, top .25s ease;
+  }
+
+  .home-mobile-menu-toggle-lines::before { top:2px; }
+  .home-mobile-menu-toggle-lines::after { top:7px; }
+  .home-mobile-menu-toggle[aria-expanded="true"] .home-mobile-menu-toggle-lines::before {
+    top:4px;
+    transform:rotate(45deg);
+  }
+  .home-mobile-menu-toggle[aria-expanded="true"] .home-mobile-menu-toggle-lines::after {
+    top:4px;
+    transform:rotate(-45deg);
+  }
+
+  .home-mobile-menu {
+    position:fixed;
+    inset:0;
+    z-index:160;
+    display:flex;
+    align-items:flex-end;
+    justify-content:center;
+    isolation:isolate;
+  }
+
+  .home-mobile-menu[hidden] { display:none; }
+
+  .home-mobile-menu-backdrop {
+    position:absolute;
+    inset:0;
+    background:linear-gradient(180deg,rgba(3,9,16,.22),rgba(5,14,23,.52));
+    backdrop-filter:blur(7px) saturate(1.04);
+    -webkit-backdrop-filter:blur(7px) saturate(1.04);
+  }
+
+  .home-mobile-menu-panel {
+    position:relative;
+    width:100%;
+    max-height:82dvh;
+    overflow:auto;
+    padding:22px 20px 30px;
+    border-top:1px solid rgba(255,255,255,.72);
+    border-radius:30px 30px 0 0;
+    background:
+      linear-gradient(148deg,rgba(245,250,255,.92),rgba(207,224,238,.80) 58%,rgba(239,225,199,.63)),
+      rgba(222,233,242,.80);
+    backdrop-filter:blur(40px) saturate(1.25) brightness(1.06);
+    -webkit-backdrop-filter:blur(40px) saturate(1.25) brightness(1.06);
+    box-shadow:0 -28px 84px rgba(7,27,45,.28), inset 0 1px 0 rgba(255,255,255,.9);
+    color:#173247;
+    animation:homeMobileSheetIn .42s cubic-bezier(.2,.82,.2,1) both;
+  }
+
+  .home-mobile-menu-panel::before {
+    content:"";
+    display:block;
+    width:42px;
+    height:4px;
+    margin:0 auto 24px;
+    border-radius:99px;
+    background:rgba(46,76,98,.20);
+  }
+
+  .home-mobile-menu-meta {
+    display:flex;
+    align-items:center;
+    justify-content:space-between;
+    gap:18px;
+    padding-bottom:16px;
+    border-bottom:1px solid rgba(49,79,103,.18);
+    font-family:var(--font-label);
+    font-size:9px;
+    font-weight:650;
+    letter-spacing:.15em;
+    text-transform:uppercase;
+    color:rgba(35,67,94,.50);
+  }
+
+  .home-mobile-menu-meta strong {
+    color:#153149;
+    font-weight:700;
+  }
+
+  .home-mobile-menu-links {
+    display:grid;
+    margin-top:5px;
+  }
+
+  .home-mobile-menu-link {
+    display:grid;
+    grid-template-columns:38px minmax(0,1fr) auto;
+    align-items:center;
+    gap:12px;
+    min-height:66px;
+    border-bottom:1px solid rgba(49,79,103,.16);
+    color:#18324a;
+  }
+
+  .home-mobile-menu-index {
+    font-family:var(--font-label);
+    font-size:9px;
+    letter-spacing:.12em;
+    color:rgba(39,75,103,.42);
+  }
+
+  .home-mobile-menu-label {
+    font-family:var(--font-display);
+    font-size:clamp(22px,7vw,29px);
+    font-weight:580;
+    letter-spacing:-.045em;
+  }
+
+  .home-mobile-menu-arrow {
+    font-family:var(--font-label);
+    font-size:12px;
+    color:rgba(39,75,103,.38);
+  }
+
+  .home-mobile-menu-link:focus-visible {
+    outline:2px solid rgba(73,137,187,.72);
+    outline-offset:-2px;
+  }
+
+  .home-mobile-menu-foot {
+    display:flex;
+    justify-content:space-between;
+    gap:16px;
+    padding-top:18px;
+    font-family:var(--font-label);
+    font-size:8px;
+    letter-spacing:.13em;
+    text-transform:uppercase;
+    color:rgba(35,67,94,.43);
+  }
+
+  body.home-mobile-menu-open { overflow:hidden; }
+
+  @keyframes homeMobileSheetIn {
+    from { opacity:0; transform:translateY(44px); }
+    to { opacity:1; transform:none; }
+  }
+}
+
+@media (max-width:430px) {
+  .home-mobile-menu-toggle { padding:7px 9px; }
+  .home-mobile-menu-toggle-text { display:none; }
+  .home-mobile-menu-panel { padding-left:18px; padding-right:18px; }
+}
+
+@media (prefers-reduced-motion:reduce) {
+  .home-mobile-menu-panel { animation:none!important; }
+  .home-mobile-menu-toggle-lines::before,
+  .home-mobile-menu-toggle-lines::after { transition:none!important; }
+}

--- a/static/html/pages/design.html
+++ b/static/html/pages/design.html
@@ -1,182 +1,152 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ko">
 <head>
-  <div data-include="/html/components/meta.html"></div>
-  <title>Design - PadiemAI</title>
-  <meta name="description" content="파디엠 디자인 쇼룸. 사람별 기억책장, LP 플레이어, 메모리테이프, 인피니트 비디오월 등 디자인 아카이브를 영상과 설명으로 만나보세요.">
-  <link rel="stylesheet" href="/css/style.css">
-  <link rel="stylesheet" href="/css/components/video-showcase.css">
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <meta name="theme-color" content="#06080d" />
+  <meta name="description" content="PADIEM Design — 기억, 감정, 움직임과 인터랙션을 독창적인 구조로 설계하는 파디엠 디자인 아카이브." />
+  <title>PADIEM Design</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans+KR:wght@300;400;500;600;700&family=Manrope:wght@400;500;600;700&display=swap" rel="stylesheet" />
+  <link href="https://cdn.jsdelivr.net/gh/sun-typeface/SUIT@2/fonts/variable/woff2/SUIT-Variable.css" rel="stylesheet" />
+  <link href="https://cdn.jsdelivr.net/gh/sun-typeface/SUITE@2/fonts/variable/woff2/SUITE-Variable.css" rel="stylesheet" />
+  <link rel="stylesheet" href="/css/padiem-cinematic-v2-1.css" />
+  <link rel="stylesheet" href="/css/padiem-cinematic-v2-2.css" />
+  <link rel="stylesheet" href="/css/padiem-cinematic-v2-3.css" />
+  <link rel="stylesheet" href="/css/padiem-cinematic-v2-4.css" />
+  <link rel="stylesheet" href="/css/padiem-cinematic-worlds-v1.css" />
 </head>
-<body>
-  <div data-include="/html/components/header.html"></div>
+<body class="world-body" data-font="suite">
+  <div class="progress-line" data-world-progress aria-hidden="true"></div>
+  <div class="world-page">
+    <header class="nav world-nav">
+      <nav class="nav-inner" aria-label="주요 메뉴">
+        <a class="logo" href="/" aria-label="PADIEM 홈">
+          <svg class="logo-mark" viewBox="0 0 32 32" fill="none" aria-hidden="true"><path d="M6 25V7h8.5c5.2 0 8.5 2.8 8.5 7.1 0 4.4-3.3 7.2-8.5 7.2H10" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/><path d="M10 11h4.5c2.5 0 4 1.1 4 3.1s-1.5 3.2-4 3.2H10" stroke="url(#wg)" stroke-width="1.6" stroke-linecap="round"/><defs><linearGradient id="wg" x1="10" y1="11" x2="19" y2="19"><stop stop-color="#8BCBFF"/><stop offset="1" stop-color="#F0C77C"/></linearGradient></defs></svg>
+          <span>PADIEM</span>
+        </a>
+        <div class="nav-links">
+          <a class="nav-link" href="/#solutions">Solutions</a>
+          <a class="nav-link" href="/#evolution">Evolution</a>
+          <a class="nav-link" href="/products/">Products</a>
+          <a class="nav-link" href="/design/" aria-current="page">Design</a>
+          <a class="nav-link" href="#company" data-world-drawer="company">Company</a>
+        </div>
+        <div class="world-nav-tools">
+          <div class="world-lang" aria-label="Language"><button type="button" data-world-lang="ko">KO</button><span>/</span><button type="button" data-world-lang="en">EN</button></div>
+          <a class="nav-cta" href="https://chat.padiem.net" aria-label="Padiem Chat">Padiem Chat</a>
+        </div>
+      </nav>
+    </header>
 
-  <!-- 페이지 헤더 -->
-  <section class="page-header design-header">
-    <div class="container">
-      <h1>Design</h1>
-      <p class="page-subtitle">파디엠 디자인 아카이브를 만나보세요<br>AI와 디자인, 기억과 감정이 만나는 공간</p>
+    <main>
+      <section class="world-hero">
+        <div class="world-hero-top reveal">
+          <div class="world-hero-index">
+            <p class="world-overline"><strong>DESIGN ARCHIVE</strong> / PADIEM</p>
+            <p class="world-overline">MEMORY · EMOTION · MOTION · DISCOVERY</p>
+          </div>
+          <p class="world-hero-note" data-copy-ko="파디엠의 디자인은 화면을 꾸미는 일이 아니라, 기억과 감정과 정보를 어떤 구조로 경험하게 할 것인가를 설계하는 일입니다." data-copy-en="PADIEM design is not decoration. It defines the structure through which people experience memory, emotion and information.">파디엠의 디자인은 화면을 꾸미는 일이 아니라, 기억과 감정과 정보를 어떤 구조로 경험하게 할 것인가를 설계하는 일입니다.</p>
+        </div>
+        <div class="world-hero-bottom">
+          <h1 class="world-display reveal" data-delay="100">Design<span class="ghost">as behavior.</span></h1>
+          <aside class="world-hero-ledger reveal" data-delay="220" aria-label="Design archive index">
+            <dl>
+              <div><dt>01</dt><dd>사람별 기억책장 · Person memory</dd></div>
+              <div><dt>02</dt><dd>LP 플레이어 · Memory playback</dd></div>
+              <div><dt>03</dt><dd>메모리테이프 · Continuous memory</dd></div>
+              <div><dt>04</dt><dd>인피니트 비디오월 · Moving archive</dd></div>
+            </dl>
+          </aside>
+        </div>
+      </section>
+
+      <section class="world-scene" style="--scene-rgb:175,211,241">
+        <div class="world-scene-head reveal"><span class="world-scene-code">DESIGN / 01</span><span class="world-scene-status"><i></i> MEMORY STRUCTURE</span></div>
+        <div class="world-scene-body">
+          <div class="world-copy reveal" data-delay="80">
+            <p class="world-kicker">PERSON MEMORY SHELF</p>
+            <h2 class="world-title" data-copy-ko="기억을 사람별 공간으로 정리합니다." data-copy-en="Memory becomes a space organized by people.">기억을 사람별 공간으로 정리합니다.</h2>
+            <p class="world-summary" data-copy-ko="사람별 기억책장은 사진을 날짜순으로만 쌓지 않고, 한 사람과 연결된 순간들을 하나의 공간적 구조로 모아 다시 발견하게 하는 인터페이스입니다." data-copy-en="The Person Memory Shelf gathers moments connected to a person into a spatial structure instead of reducing memory to a chronological photo list.">사람별 기억책장은 사진을 날짜순으로만 쌓지 않고, 한 사람과 연결된 순간들을 하나의 공간적 구조로 모아 다시 발견하게 하는 인터페이스입니다.</p>
+            <div class="world-actions"><span class="world-action-secondary" data-copy-ko="공개 영상 준비 중" data-copy-en="Public media in preparation">공개 영상 준비 중</span></div>
+          </div>
+          <div class="world-media reveal" data-delay="170"><div class="world-media-frame"><span class="world-media-label">MEMORY / PERSON / SHELF</span><div class="world-media-message"><strong>사람별<br/>기억책장</strong><span>SPATIAL MEMORY</span></div></div></div>
+        </div>
+        <div class="world-scene-foot reveal"><div class="world-tags"><span>Person</span><span>Memory</span><span>Spatial</span><span>Discovery</span></div><span class="world-number">01</span></div>
+      </section>
+
+      <section class="world-scene" style="--scene-rgb:239,196,123">
+        <div class="world-scene-head reveal"><span class="world-scene-code">DESIGN / 02</span><span class="world-scene-status"><i></i> PLAYBACK METAPHOR</span></div>
+        <div class="world-scene-body">
+          <div class="world-copy reveal" data-delay="80">
+            <p class="world-kicker">LP PLAYER · MEMORY PLAYBACK</p>
+            <h2 class="world-title" data-copy-ko="기억을 고르는 대신, 재생합니다." data-copy-en="Instead of selecting memory, play it.">기억을 고르는 대신, 재생합니다.</h2>
+            <p class="world-summary" data-copy-ko="LP 플레이어는 기억을 파일 목록처럼 탐색하지 않고 음악을 재생하듯 시간과 감정의 흐름을 따라 경험하게 하는 인터랙션 메타포입니다." data-copy-en="The LP Player treats memory not as a file list but as a temporal and emotional flow that can be played like music.">LP 플레이어는 기억을 파일 목록처럼 탐색하지 않고 음악을 재생하듯 시간과 감정의 흐름을 따라 경험하게 하는 인터랙션 메타포입니다.</p>
+            <div class="world-actions"><span class="world-action-secondary" data-copy-ko="공개 영상 준비 중" data-copy-en="Public media in preparation">공개 영상 준비 중</span></div>
+          </div>
+          <div class="world-media reveal" data-delay="170"><div class="world-media-frame"><span class="world-media-label">LP / ROTATION / TIME</span><div class="world-media-message"><strong>LP<br/>PLAYER</strong><span>MEMORY PLAYBACK</span></div></div></div>
+        </div>
+        <div class="world-scene-foot reveal"><div class="world-tags"><span>Rotation</span><span>Time</span><span>Playback</span><span>Emotion</span></div><span class="world-number">02</span></div>
+      </section>
+
+      <section class="world-scene" style="--scene-rgb:183,205,229">
+        <div class="world-scene-head reveal"><span class="world-scene-code">DESIGN / 03</span><span class="world-scene-status"><i></i> MECHANICS FIRST</span></div>
+        <div class="world-scene-body">
+          <div class="world-copy reveal" data-delay="80">
+            <p class="world-kicker">MEMORY TAPE · CONTINUOUS RIBBON</p>
+            <h2 class="world-title" data-copy-ko="지나온 경로가 하나의 기록으로 풀립니다." data-copy-en="The path you travel unrolls as one continuous record.">지나온 경로가 하나의 기록으로 풀립니다.</h2>
+            <p class="world-summary" data-copy-ko="메모리테이프의 핵심은 카드 장식이 아니라 물성입니다. 사용자의 이동 경로를 따라 실제 롤이 굴러가고, 하나의 연속된 리본처럼 기억이 풀려 나오는 구조를 목표로 합니다." data-copy-en="Memory Tape is defined by mechanics, not card decoration: a real rolling metaphor and one continuous ribbon that records the user's path.">메모리테이프의 핵심은 카드 장식이 아니라 물성입니다. 사용자의 이동 경로를 따라 실제 롤이 굴러가고, 하나의 연속된 리본처럼 기억이 풀려 나오는 구조를 목표로 합니다.</p>
+            <div class="world-actions"><span class="world-action-secondary">MECHANICS FIRST → VISUAL FIDELITY → CONTENT</span></div>
+          </div>
+          <div class="world-media reveal" data-delay="170"><div class="world-media-frame"><span class="world-media-label">ROLL / RIBBON / PATH</span><div class="world-media-message"><strong>MEMORY<br/>TAPE</strong><span>CONTINUOUS INTERACTION</span></div></div></div>
+        </div>
+        <div class="world-scene-foot reveal"><div class="world-tags"><span>Roll</span><span>Ribbon</span><span>Path</span><span>3D</span></div><span class="world-number">03</span></div>
+      </section>
+
+      <section class="world-scene" style="--scene-rgb:153,194,229">
+        <div class="world-scene-head reveal"><span class="world-scene-code">DESIGN / 04</span><span class="world-scene-status"><i></i> MOVING FIELD</span></div>
+        <div class="world-scene-body">
+          <div class="world-copy reveal" data-delay="80">
+            <p class="world-kicker">INFINITE VIDEO WALL</p>
+            <h2 class="world-title" data-copy-ko="수많은 순간이 하나의 움직이는 장면이 됩니다." data-copy-en="Many moments become one moving field.">수많은 순간이 하나의 움직이는 장면이 됩니다.</h2>
+            <p class="world-summary" data-copy-ko="인피니트 비디오월은 수많은 Moving Moment가 동시에 존재하는 고밀도 필드입니다. 하나의 카드보다 전체 장면의 흐름과 발견 경험이 먼저 보이는 구조입니다." data-copy-en="Infinite Video Wall is a dense field where many moving moments coexist. The flow of the whole scene comes before any single card.">인피니트 비디오월은 수많은 Moving Moment가 동시에 존재하는 고밀도 필드입니다. 하나의 카드보다 전체 장면의 흐름과 발견 경험이 먼저 보이는 구조입니다.</p>
+            <div class="world-actions"><span class="world-action-secondary" data-copy-ko="공개 영상 준비 중" data-copy-en="Public media in preparation">공개 영상 준비 중</span></div>
+          </div>
+          <div class="world-media reveal" data-delay="170"><div class="world-media-frame"><span class="world-media-label">VIDEO / FIELD / DISCOVERY</span><div class="world-media-message"><strong>INFINITE<br/>VIDEO WALL</strong><span>MOVING ARCHIVE</span></div></div></div>
+        </div>
+        <div class="world-scene-foot reveal"><div class="world-tags"><span>Field</span><span>Motion</span><span>Archive</span><span>Discovery</span></div><span class="world-number">04</span></div>
+      </section>
+
+      <section class="world-scene world-archive-intro" style="--scene-rgb:205,190,238">
+        <div class="world-scene-head reveal"><span class="world-scene-code">ARCHIVE / NEXT</span><span class="world-scene-status"><i></i> CURATING</span></div>
+        <div>
+          <div class="world-copy reveal"><p class="world-kicker">MORE INTERACTION STRUCTURES</p><h2 class="world-title" data-copy-ko="하나의 템플릿보다, 서로 다른 경험 구조를 축적합니다." data-copy-en="We accumulate distinct interaction structures instead of one reusable template.">하나의 템플릿보다, 서로 다른 경험 구조를 축적합니다.</h2></div>
+          <div class="world-archive-grid">
+            <article class="world-archive-tile feature reveal"><span class="tile-index">05 / 3D MEMORY SHELF</span><div><h2>3D<br/>기억책장</h2><div class="tile-line"></div><p data-copy-ko="기억을 평면 목록이 아니라 공간 탐색 대상으로 바꾸는 3D 구조." data-copy-en="A 3D structure that turns memory from a flat list into a spatial exploration.">기억을 평면 목록이 아니라 공간 탐색 대상으로 바꾸는 3D 구조.</p></div></article>
+            <article class="world-archive-tile medium reveal" data-delay="80"><span class="tile-index">06 / ROTATING MEMORY INDEX</span><div><h2>로테이팅<br/>메모리 인덱스</h2><div class="tile-line"></div><p data-copy-ko="한 Moment씩 집중해 넘겨보는 sequential reader 구조." data-copy-en="A sequential reader for focusing on one Moment at a time.">한 Moment씩 집중해 넘겨보는 sequential reader 구조.</p></div></article>
+            <article class="world-archive-tile small reveal"><span class="tile-index">07 / MOMENT REVEAL</span><div><h2>모먼트<br/>리빌</h2><div class="tile-line"></div><p data-copy-ko="같은 인물과 순간의 상태 변화를 정합된 프레임 위에서 드러내는 reveal interaction." data-copy-en="A reveal interaction that exposes state changes across aligned frames of the same person and moment.">같은 인물과 순간의 상태 변화를 정합된 프레임 위에서 드러내는 reveal interaction.</p></div></article>
+            <article class="world-archive-tile wide reveal" data-delay="100"><span class="tile-index">EDITORIAL ARCHIVE PRINCIPLE</span><div><h2>Content before chrome.</h2><div class="tile-line"></div><p data-copy-ko="모든 콘텐츠를 같은 카드 비율로 자르지 않습니다. 원본 비율, 중요도, 여백과 편집 리듬이 UI보다 먼저입니다." data-copy-en="Not every piece of content is forced into the same card ratio. Native proportion, importance, negative space and editorial rhythm come before UI chrome.">모든 콘텐츠를 같은 카드 비율로 자르지 않습니다. 원본 비율, 중요도, 여백과 편집 리듬이 UI보다 먼저입니다.</p></div></article>
+          </div>
+        </div>
+        <div class="world-scene-foot"><div class="world-tags"><span>Native ratio</span><span>Editorial rhythm</span><span>Mechanics</span><span>Motion</span></div><span class="world-number">05+</span></div>
+      </section>
+    </main>
+
+    <footer class="world-footer"><span>© PADIEM CO., LTD.</span><span>DESIGN · MEMORY · MOTION · INTERACTION</span></footer>
+  </div>
+
+  <div id="worldCompanyOverlay" class="overlay" hidden aria-hidden="true" aria-modal="true" role="dialog" aria-labelledby="worldDrawerTitle">
+    <div class="overlay-backdrop" data-world-drawer-close></div>
+    <div class="overlay-panel" role="document">
+      <button class="overlay-close" type="button" data-world-drawer-close aria-label="닫기"><svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 6 6 18M6 6l12 12"/></svg></button>
+      <p id="worldDrawerKicker" class="overlay-kicker mono"></p>
+      <h2 id="worldDrawerTitle" class="overlay-title"></h2>
+      <p id="worldDrawerLead" class="overlay-lead"></p>
+      <div id="worldDrawerBody" class="overlay-body"></div>
     </div>
-  </section>
+  </div>
 
-  <main>
-    <!-- 디자인 1: 사람별 기억책장 -->
-    <section class="video-showcase-section fade-in">
-      <div class="container">
-        <div class="showcase-item">
-          <div class="showcase-media">
-            <div class="video-wrapper">
-              <div class="video-placeholder" data-design="person-memory-shelf">
-                <div class="placeholder-content">
-                  <i class="fas fa-play"></i>
-                  <p>영상 준비 중</p>
-                </div>
-                <div class="video-tag">Coming Soon</div>
-              </div>
-            </div>
-          </div>
-          <div class="showcase-content">
-            <h2 class="showcase-title">사람별 기억책장</h2>
-            <p class="showcase-subtitle">Personal Memory Shelf</p>
-            <div class="showcase-description">
-              <p>사람마다의 기억을 시각화한 개인 맞춤형 책장 인터페이스. 각 사람의 기억 조각이 책장 속에서 공간적으로 엮이며, 클릭과 스크롤을 통해 추억의 시간 순서를 떠다닐 수 있다.</p>
-              <ul class="feature-list">
-                <li>개인 기억 시각화</li>
-                <li>시간 흐름 기반 내비게이션</li>
-                <li>감정 태그 시스템</li>
-                <li>공유 및 협업 기능</li>
-              </ul>
-            </div>
-          </div>
-        </div>
-      </div>
-    </section>
-
-    <!-- 디자인 2: LP 플레이어 -->
-    <section class="video-showcase-section bg-light fade-in">
-      <div class="container">
-        <div class="showcase-item reverse">
-          <div class="showcase-media">
-            <div class="video-wrapper">
-              <div class="video-placeholder" data-design="lp-player">
-                <div class="placeholder-content">
-                  <i class="fas fa-play"></i>
-                  <p>영상 준비 중</p>
-                </div>
-                <div class="video-tag">Coming Soon</div>
-              </div>
-            </div>
-          </div>
-          <div class="showcase-content">
-            <h2 class="showcase-title">LP 플레이어</h2>
-            <p class="showcase-subtitle">LP Player — Memory Playback Interface</p>
-            <div class="showcase-description">
-              <p>레코드 판처럼 돌아가는 기억 재생 인터페이스. 시간이 흐르면서 회상이 스쳐오르는 감성적인 재생 경험. 기억의 끊김 없는 흐름을 음악처럼 부드럽게 이어준다.</p>
-              <ul class="feature-list">
-                <li>시간 기반 회상 재생</li>
-                <li>감정 워이브 시각화</li>
-                <li>음성/텍스트 동시 재생</li>
-                <li>기억 큐레이션 도구</li>
-              </ul>
-            </div>
-          </div>
-        </div>
-      </div>
-    </section>
-
-    <!-- 디자인 3: 메모리테이프 -->
-    <section class="video-showcase-section fade-in">
-      <div class="container">
-        <div class="showcase-item">
-          <div class="showcase-media">
-            <div class="video-wrapper">
-              <div class="video-placeholder" data-design="memory-tape">
-                <div class="placeholder-content">
-                  <i class="fas fa-play"></i>
-                  <p>영상 준비 중</p>
-                </div>
-                <div class="video-tag">Coming Soon</div>
-              </div>
-            </div>
-          </div>
-          <div class="showcase-content">
-            <h2 class="showcase-title">메모리테이프</h2>
-            <p class="showcase-subtitle">Memory Tape — Temporal Memory Interface</p>
-            <div class="showcase-description">
-              <p>메모리 테이프는 기억을 선형의 테이프처럼 되감고 빨리강하는 인터페이스. 특정 시점의 대화, 사진, 감정 데이터를 실시간 스크러빙으로 탐색한다.</p>
-              <ul class="feature-list">
-                <li>시간축 스크러빙</li>
-                <li>멀티모달 기억 재생</li>
-                <li>감정 흐름 분석</li>
-                <li>음성 기록 동기화</li>
-              </ul>
-            </div>
-          </div>
-        </div>
-      </div>
-    </section>
-
-    <!-- 디자인 4: 인피니트 비디오월 -->
-    <section class="video-showcase-section bg-light fade-in">
-      <div class="container">
-        <div class="showcase-item reverse">
-          <div class="showcase-media">
-            <div class="video-wrapper">
-              <div class="video-placeholder" data-design="infinite-video-wall">
-                <div class="placeholder-content">
-                  <i class="fas fa-play"></i>
-                  <p>영상 준비 중</p>
-                </div>
-                <div class="video-tag">Coming Soon</div>
-              </div>
-            </div>
-          </div>
-          <div class="showcase-content">
-            <h2 class="showcase-title">인피니트 비디오월</h2>
-            <p class="showcase-subtitle">Infinite Video Wall — Memory Grid Interface</p>
-            <div class="showcase-description">
-              <p> 무한히 확장되는 기억의 벽. 사진, 영상, 메모가 격자 형태로 펼쳐지며, 줌과 스크롤을 통해 세부 기억으로 파고든다. 관계와 시간의 연결 고리를 시각적으로 탐색한다.</p>
-              <ul class="feature-list">
-                <li>무한 확장 그리드</li>
-                <li>관계 맺음선 시각화</li>
-                <li>AI 기반 기억 클러스터링</li>
-                <li>멀티터치 조작</li>
-              </ul>
-            </div>
-          </div>
-        </div>
-      </div>
-    </section>
-
-    <!-- 준비 중인 디자인 -->
-    <section class="video-showcase-section fade-in">
-      <div class="container">
-        <div class="showcase-item">
-          <div class="showcase-media">
-            <div class="video-wrapper">
-              <div class="video-placeholder" data-design="coming-soon">
-                <div class="placeholder-content">
-                  <i class="fas fa-cube"></i>
-                  <p>영상 준비 중</p>
-                </div>
-                <div class="video-tag">Coming Soon</div>
-              </div>
-            </div>
-          </div>
-          <div class="showcase-content">
-            <h2 class="showcase-title">준비 중인 디자인</h2>
-            <p class="showcase-subtitle">3D 기억책장 / 로테이팅 메모리 인덱스</p>
-            <div class="showcase-description">
-              <p>파디엠 디자인은 계속 성장합니다. 3D 기억책장과 로테이팅 메모리 인덱스 등 새로운 디자인 프로젝트가 준비 중입니다.</p>
-            </div>
-          </div>
-        </div>
-      </div>
-    </section>
-  </main>
-
-  <div data-include="/html/components/footer.html"></div>
-  <script src="/js/include.js"></script>
-  <script src="/js/main.js"></script>
-  <script src="/js/mobile-menu.js"></script>
+  <script src="/js/padiem-cinematic-worlds-v1.js"></script>
 </body>
 </html>

--- a/static/html/pages/products.html
+++ b/static/html/pages/products.html
@@ -1,173 +1,152 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ko">
 <head>
-  <div data-include="/html/components/meta.html"></div>
-  <title>Products - PadiemAI</title>
-  <meta name="description" content="파디엠 제품 쇼룸. Padiem Chat, StoryMemory, LoveTree, 단지온 등 AI 제품들을 영상과 설명으로 만나보세요.">
-  <link rel="stylesheet" href="/css/style.css">
-  <link rel="stylesheet" href="/css/components/video-showcase.css">
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <meta name="theme-color" content="#06080d" />
+  <meta name="description" content="PADIEM Products — Padiem Chat, StoryMemory, LoveTree, 단지온을 하나의 시네마틱 제품 세계로 소개합니다." />
+  <title>PADIEM Products</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans+KR:wght@300;400;500;600;700&family=Manrope:wght@400;500;600;700&display=swap" rel="stylesheet" />
+  <link href="https://cdn.jsdelivr.net/gh/sun-typeface/SUIT@2/fonts/variable/woff2/SUIT-Variable.css" rel="stylesheet" />
+  <link href="https://cdn.jsdelivr.net/gh/sun-typeface/SUITE@2/fonts/variable/woff2/SUITE-Variable.css" rel="stylesheet" />
+  <link rel="stylesheet" href="/css/padiem-cinematic-v2-1.css" />
+  <link rel="stylesheet" href="/css/padiem-cinematic-v2-2.css" />
+  <link rel="stylesheet" href="/css/padiem-cinematic-v2-3.css" />
+  <link rel="stylesheet" href="/css/padiem-cinematic-v2-4.css" />
+  <link rel="stylesheet" href="/css/padiem-cinematic-worlds-v1.css" />
 </head>
-<body>
-  <div data-include="/html/components/header.html"></div>
+<body class="world-body" data-font="suite">
+  <div class="progress-line" data-world-progress aria-hidden="true"></div>
+  <div class="world-page">
+    <header class="nav world-nav">
+      <nav class="nav-inner" aria-label="주요 메뉴">
+        <a class="logo" href="/" aria-label="PADIEM 홈">
+          <svg class="logo-mark" viewBox="0 0 32 32" fill="none" aria-hidden="true"><path d="M6 25V7h8.5c5.2 0 8.5 2.8 8.5 7.1 0 4.4-3.3 7.2-8.5 7.2H10" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/><path d="M10 11h4.5c2.5 0 4 1.1 4 3.1s-1.5 3.2-4 3.2H10" stroke="url(#wg)" stroke-width="1.6" stroke-linecap="round"/><defs><linearGradient id="wg" x1="10" y1="11" x2="19" y2="19"><stop stop-color="#8BCBFF"/><stop offset="1" stop-color="#F0C77C"/></linearGradient></defs></svg>
+          <span>PADIEM</span>
+        </a>
+        <div class="nav-links">
+          <a class="nav-link" href="/#solutions">Solutions</a>
+          <a class="nav-link" href="/#evolution">Evolution</a>
+          <a class="nav-link" href="/products/" aria-current="page">Products</a>
+          <a class="nav-link" href="/design/">Design</a>
+          <a class="nav-link" href="#company" data-world-drawer="company">Company</a>
+        </div>
+        <div class="world-nav-tools">
+          <div class="world-lang" aria-label="Language"><button type="button" data-world-lang="ko">KO</button><span>/</span><button type="button" data-world-lang="en">EN</button></div>
+          <a class="nav-cta" href="https://chat.padiem.net" aria-label="Padiem Chat">Padiem Chat</a>
+        </div>
+      </nav>
+    </header>
 
-  <!-- 페이지 헤더 -->
-  <section class="page-header products-header">
-    <div class="container">
-      <h1>Products</h1>
-      <p class="page-subtitle">파디엠의 AI 제품을 만나보세요<br>기술을 소개하는 데서 멈추지 않습니다. 실행으로 연결합니다</p>
+    <main>
+      <section class="world-hero">
+        <div class="world-hero-top reveal">
+          <div class="world-hero-index">
+            <p class="world-overline"><strong>PRODUCT WORLDS</strong> / PADIEM</p>
+            <p class="world-overline">CONVERSATION · MEMORY · RELATIONSHIP · COMMUNITY</p>
+          </div>
+          <p class="world-hero-note" data-copy-ko="파디엠의 제품은 기능 목록이 아니라 사람이 일을 하고, 기억하고, 관계를 맺고, 공동체를 운영하는 방식을 다시 설계합니다." data-copy-en="PADIEM products redesign how people work, remember, relate, and operate communities rather than presenting a list of AI features.">파디엠의 제품은 기능 목록이 아니라 사람이 일을 하고, 기억하고, 관계를 맺고, 공동체를 운영하는 방식을 다시 설계합니다.</p>
+        </div>
+        <div class="world-hero-bottom">
+          <h1 class="world-display reveal" data-delay="100">Products<span class="ghost">as scenes.</span></h1>
+          <aside class="world-hero-ledger reveal" data-delay="220" aria-label="Products index">
+            <dl>
+              <div><dt>01</dt><dd>Padiem Chat · Live AI frontdoor</dd></div>
+              <div><dt>02</dt><dd>StoryMemory · Reading / memory</dd></div>
+              <div><dt>03</dt><dd>LoveTree · Emotional memory</dd></div>
+              <div><dt>04</dt><dd>단지온 · Community operation</dd></div>
+            </dl>
+          </aside>
+        </div>
+      </section>
+
+      <section class="world-scene" style="--scene-rgb:136,201,255">
+        <div class="world-scene-head reveal"><span class="world-scene-code">PRODUCT / 01</span><span class="world-scene-status"><i></i> LIVE</span></div>
+        <div class="world-scene-body">
+          <div class="world-copy reveal" data-delay="80">
+            <p class="world-kicker">GENERAL AI FRONTDOOR</p>
+            <h2 class="world-title" data-copy-ko="대화에서 일이 시작됩니다." data-copy-en="Work begins with a conversation.">대화에서 일이 시작됩니다.</h2>
+            <p class="world-summary" data-copy-ko="Padiem Chat은 파디엠의 공식 AI 진입점입니다. 누구나 바로 질문하고, 검색하고, 파일을 연결하며 필요한 작업의 다음 단계로 넘어갈 수 있습니다." data-copy-en="Padiem Chat is the official PADIEM AI frontdoor: ask, search, attach files and move directly into the next step of work.">Padiem Chat은 파디엠의 공식 AI 진입점입니다. 누구나 바로 질문하고, 검색하고, 파일을 연결하며 필요한 작업의 다음 단계로 넘어갈 수 있습니다.</p>
+            <div class="world-actions"><a class="world-action-primary" href="https://chat.padiem.net" data-copy-ko="파디엠 챗 사용하기" data-copy-en="Open Padiem Chat">파디엠 챗 사용하기</a></div>
+          </div>
+          <div class="world-media reveal" data-delay="170" aria-label="Padiem Chat visual field">
+            <div class="world-media-frame"><span class="world-media-label">PADIEM CHAT / LIVE SURFACE</span><div class="world-media-message"><strong>PADIEM CHAT</strong><span>CHAT.PADIEM.NET</span></div></div>
+          </div>
+        </div>
+        <div class="world-scene-foot reveal"><div class="world-tags"><span>Ask</span><span>Search</span><span>Files</span><span>Projects</span></div><span class="world-number">01</span></div>
+      </section>
+
+      <section class="world-scene" style="--scene-rgb:183,206,232">
+        <div class="world-scene-head reveal"><span class="world-scene-code">PRODUCT / 02</span><span class="world-scene-status"><i></i> IN DEVELOPMENT</span></div>
+        <div class="world-scene-body">
+          <div class="world-copy reveal" data-delay="80">
+            <p class="world-kicker">READING · MEMORY INTERFACE</p>
+            <h2 class="world-title" data-copy-ko="읽은 문장이 기억이 되는 방식." data-copy-en="When reading becomes memory.">읽은 문장이 기억이 되는 방식.</h2>
+            <p class="world-summary" data-copy-ko="StoryMemory는 책, 문장, 메모와 회상을 끊어진 기록으로 두지 않고 하나의 읽기·기억 흐름으로 연결하는 제품입니다." data-copy-en="StoryMemory connects books, sentences, notes and recall into one continuous reading-and-memory experience.">StoryMemory는 책, 문장, 메모와 회상을 끊어진 기록으로 두지 않고 하나의 읽기·기억 흐름으로 연결하는 제품입니다.</p>
+            <div class="world-actions"><span class="world-action-secondary" data-copy-ko="공개 영상 준비 중" data-copy-en="Public media in preparation">공개 영상 준비 중</span></div>
+          </div>
+          <div class="world-media reveal" data-delay="170"><div class="world-media-frame"><span class="world-media-label">STORYMEMORY / READING MEMORY</span><div class="world-media-message"><strong>STORY<br/>MEMORY</strong><span>MEDIA FIELD RESERVED</span></div></div></div>
+        </div>
+        <div class="world-scene-foot reveal"><div class="world-tags"><span>Reading</span><span>Sentence</span><span>Recall</span><span>Memory</span></div><span class="world-number">02</span></div>
+      </section>
+
+      <section class="world-scene" style="--scene-rgb:239,196,123">
+        <div class="world-scene-head reveal"><span class="world-scene-code">PRODUCT / 03</span><span class="world-scene-status"><i></i> IN DEVELOPMENT</span></div>
+        <div class="world-scene-body">
+          <div class="world-copy reveal" data-delay="80">
+            <p class="world-kicker">EMOTIONAL MEMORY · MOTION INTERFACE</p>
+            <h2 class="world-title" data-copy-ko="사람과 순간을 움직이는 기억으로." data-copy-en="People and moments, kept in motion.">사람과 순간을 움직이는 기억으로.</h2>
+            <p class="world-summary" data-copy-ko="LoveTree는 사진을 카드로 쌓는 데서 끝나지 않습니다. 사람, 순간, 감정의 경로를 공간·움직임·인터랙션으로 다시 경험하게 만드는 기억 제품입니다." data-copy-en="LoveTree goes beyond storing photos as cards. It turns people, moments and emotional paths into spatial and interactive memory experiences.">LoveTree는 사진을 카드로 쌓는 데서 끝나지 않습니다. 사람, 순간, 감정의 경로를 공간·움직임·인터랙션으로 다시 경험하게 만드는 기억 제품입니다.</p>
+            <div class="world-actions"><span class="world-action-secondary" data-copy-ko="공개 영상 준비 중" data-copy-en="Public media in preparation">공개 영상 준비 중</span></div>
+          </div>
+          <div class="world-media reveal" data-delay="170"><div class="world-media-frame"><span class="world-media-label">LOVETREE / MEMORY IN MOTION</span><div class="world-media-message"><strong>LOVE<br/>TREE</strong><span>MOTION INTERFACE</span></div></div></div>
+        </div>
+        <div class="world-scene-foot reveal"><div class="world-tags"><span>People</span><span>Moments</span><span>Emotion</span><span>Motion</span></div><span class="world-number">03</span></div>
+      </section>
+
+      <section class="world-scene" style="--scene-rgb:126,221,230">
+        <div class="world-scene-head reveal"><span class="world-scene-code">PRODUCT / 04</span><span class="world-scene-status"><i></i> IN DEVELOPMENT</span></div>
+        <div class="world-scene-body">
+          <div class="world-copy reveal" data-delay="80">
+            <p class="world-kicker">COMMUNITY · OPERATION</p>
+            <h2 class="world-title" data-copy-ko="공동체의 절차를 더 명확하게." data-copy-en="Clearer operations for communities.">공동체의 절차를 더 명확하게.</h2>
+            <p class="world-summary" data-copy-ko="단지온은 공지, 민원, 회의와 의사결정처럼 복잡해지기 쉬운 공동주택 운영의 흐름을 주민과 관리 주체가 함께 이해할 수 있도록 정리합니다." data-copy-en="DanjiOn clarifies notices, complaints, meetings and decision flows so residents and operators can understand community operations together.">단지온은 공지, 민원, 회의와 의사결정처럼 복잡해지기 쉬운 공동주택 운영의 흐름을 주민과 관리 주체가 함께 이해할 수 있도록 정리합니다.</p>
+            <div class="world-actions"><span class="world-action-secondary" data-copy-ko="공개 영상 준비 중" data-copy-en="Public media in preparation">공개 영상 준비 중</span></div>
+          </div>
+          <div class="world-media reveal" data-delay="170"><div class="world-media-frame"><span class="world-media-label">DANJION / COMMUNITY FLOW</span><div class="world-media-message"><strong>단지온</strong><span>COMMUNITY OPERATION</span></div></div></div>
+        </div>
+        <div class="world-scene-foot reveal"><div class="world-tags"><span>Notice</span><span>Meeting</span><span>Decision</span><span>Community</span></div><span class="world-number">04</span></div>
+      </section>
+
+      <section class="world-scene world-archive-intro" style="--scene-rgb:174,190,255">
+        <div class="world-scene-head reveal"><span class="world-scene-code">NEXT / EXPERIMENTS</span><span class="world-scene-status"><i></i> PREPARING</span></div>
+        <div>
+          <div class="world-copy reveal"><p class="world-kicker">PADIEM LAB</p><h2 class="world-title" data-copy-ko="다음 제품은 아직 전시 준비 중입니다." data-copy-en="The next products are still being prepared for public display.">다음 제품은 아직 전시 준비 중입니다.</h2></div>
+          <div class="world-archive-grid">
+            <article class="world-archive-tile feature reveal"><span class="tile-index">05 / OPPORTUNITY RADAR</span><div><h2>AI 무료 레이더</h2><div class="tile-line"></div><p data-copy-ko="무료·프로모션 AI/API 기회를 공식 출처 기준으로 탐색하고 검증하는 서비스." data-copy-en="A service that discovers and verifies free or promotional AI/API opportunities from official sources.">무료·프로모션 AI/API 기회를 공식 출처 기준으로 탐색하고 검증하는 서비스.</p></div></article>
+            <article class="world-archive-tile medium reveal" data-delay="100"><span class="tile-index">PADIEM / NEXT</span><div><h2>More<br/>to come.</h2><div class="tile-line"></div><p data-copy-ko="공개 가능한 수준에 도달한 제품만 이 전시장에 추가합니다." data-copy-en="Only products ready for a public-quality presentation are added to this showroom.">공개 가능한 수준에 도달한 제품만 이 전시장에 추가합니다.</p></div></article>
+          </div>
+        </div>
+        <div class="world-scene-foot"><div class="world-tags"><span>Verified</span><span>Public-ready</span><span>No unfinished links</span></div><span class="world-number">05+</span></div>
+      </section>
+    </main>
+
+    <footer class="world-footer"><span>© PADIEM CO., LTD.</span><span>PRODUCT · MEMORY · PUBLIC · INTERACTION</span></footer>
+  </div>
+
+  <div id="worldCompanyOverlay" class="overlay" hidden aria-hidden="true" aria-modal="true" role="dialog" aria-labelledby="worldDrawerTitle">
+    <div class="overlay-backdrop" data-world-drawer-close></div>
+    <div class="overlay-panel" role="document">
+      <button class="overlay-close" type="button" data-world-drawer-close aria-label="닫기"><svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 6 6 18M6 6l12 12"/></svg></button>
+      <p id="worldDrawerKicker" class="overlay-kicker mono"></p>
+      <h2 id="worldDrawerTitle" class="overlay-title"></h2>
+      <p id="worldDrawerLead" class="overlay-lead"></p>
+      <div id="worldDrawerBody" class="overlay-body"></div>
     </div>
-  </section>
+  </div>
 
-  <main>
-    <!-- 제품 1: Padiem Chat -->
-    <section class="video-showcase-section fade-in">
-      <div class="container">
-        <div class="showcase-item">
-          <div class="showcase-media">
-            <div class="video-wrapper">
-              <div class="video-placeholder" data-product="padiem-chat">
-                <div class="placeholder-content">
-                  <i class="fas fa-robot"></i>
-                  <p>Live Preview</p>
-                </div>
-                <div class="video-tag">Live</div>
-              </div>
-            </div>
-          </div>
-          <div class="showcase-content">
-            <h2 class="showcase-title">Padiem Chat</h2>
-            <p class="showcase-subtitle">공식 AI 진입점</p>
-            <div class="showcase-description">
-              <p>파디엠의 기본 AI 대화형 작업 공간. 누구나 바로 질문하고, 검색하고, 파일과 작업 흐름을 이어갈 수 있는 AI frontdoor.</p>
-              <div class="hero-btns" style="margin-top: 2rem;">
-                <a href="https://chat.padiem.net" class="btn" target="_blank" rel="noopener">파디엠 챗 사용하기</a>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </section>
-
-    <!-- 제품 2: StoryMemory -->
-    <section class="video-showcase-section bg-light fade-in">
-      <div class="container">
-        <div class="showcase-item reverse">
-          <div class="showcase-media">
-            <div class="video-wrapper">
-              <div class="video-placeholder" data-product="story-memory">
-                <div class="placeholder-content">
-                  <i class="fas fa-play"></i>
-                  <p>영상 준비 중</p>
-                </div>
-                <div class="video-tag">Coming Soon</div>
-              </div>
-            </div>
-          </div>
-          <div class="showcase-content">
-            <h2 class="showcase-title">StoryMemory</h2>
-            <p class="showcase-subtitle">AI Reading / Memory Interface</p>
-            <div class="showcase-description">
-              <p>읽기와 기억을 이어주는 AI 독서·기억 인터페이스. 책, 문장, 메모, 회상을 하나의 흐름으로 연결한다.</p>
-              <div class="hero-btns" style="margin-top: 2rem;">
-                <a href="#" class="btn btn-outline" style="cursor: default;">자세히 준비 중</a>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </section>
-
-    <!-- 제품 3: LoveTree -->
-    <section class="video-showcase-section fade-in">
-      <div class="container">
-        <div class="showcase-item">
-          <div class="showcase-media">
-            <div class="video-wrapper">
-              <div class="video-placeholder" data-product="love-tree">
-                <div class="placeholder-content">
-                  <i class="fas fa-play"></i>
-                  <p>영상 준비 중</p>
-                </div>
-                <div class="video-tag">Coming Soon</div>
-              </div>
-            </div>
-          </div>
-          <div class="showcase-content">
-            <h2 class="showcase-title">LoveTree</h2>
-            <p class="showcase-subtitle">Emotional Memory / Motion Interface</p>
-            <div class="showcase-description">
-              <p>사람과 순간, 감정 경로를 영상형 인터페이스로 기록하는 제품. 기억, 관계, 사진, 움직임을 하나의 경험으로 엮는다.</p>
-              <div class="hero-btns" style="margin-top: 2rem;">
-                <a href="#" class="btn btn-outline" style="cursor: default;">자세히 준비 중</a>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </section>
-
-    <!-- 제품 4: 단지온 -->
-    <section class="video-showcase-section bg-light fade-in">
-      <div class="container">
-        <div class="showcase-item reverse">
-          <div class="showcase-media">
-            <div class="video-wrapper">
-              <div class="video-placeholder" data-product="danjion">
-                <div class="placeholder-content">
-                  <i class="fas fa-play"></i>
-                  <p>영상 준비 중</p>
-                </div>
-                <div class="video-tag">Coming Soon</div>
-              </div>
-            </div>
-          </div>
-          <div class="showcase-content">
-            <h2 class="showcase-title">단지온</h2>
-            <p class="showcase-subtitle">Apartment / Community Operation</p>
-            <div class="showcase-description">
-              <p>아파트와 공동체 운영을 돕는 절차·소통 플랫폼. 공지, 민원, 회의, 의사결정 흐름을 더 명확하게 만든다.</p>
-              <div class="hero-btns" style="margin-top: 2rem;">
-                <a href="#" class="btn btn-outline" style="cursor: default;">자세히 준비 중</a>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </section>
-
-    <!-- 준비 중인 제품 -->
-    <section class="video-showcase-section fade-in">
-      <div class="container">
-        <div class="showcase-item">
-          <div class="showcase-media">
-            <div class="video-wrapper">
-              <div class="video-placeholder" data-product="ai-radar">
-                <div class="placeholder-content">
-                  <i class="fas fa-bolt"></i>
-                  <p>영상 준비 중</p>
-                </div>
-                <div class="video-tag">Coming Soon</div>
-              </div>
-            </div>
-          </div>
-          <div class="showcase-content">
-            <h2 class="showcase-title">AI 무료 레이더</h2>
-            <p class="showcase-subtitle">AI/API Opportunity Radar</p>
-            <div class="showcase-description">
-              <p>무료·프로모션 AI/API 기회를 공식 출처 기준으로 정리하고 검증하는 탐색 서비스.</p>
-              <div class="hero-btns" style="margin-top: 2rem;">
-                <a href="#" class="btn btn-outline" style="cursor: default;">자세히 준비 중</a>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </section>
-  </main>
-
-  <div data-include="/html/components/footer.html"></div>
-  <script src="/js/include.js"></script>
-  <script src="/js/main.js"></script>
-  <script src="/js/mobile-menu.js"></script>
+  <script src="/js/padiem-cinematic-worlds-v1.js"></script>
 </body>
 </html>

--- a/static/js/padiem-cinematic-worlds-v1.js
+++ b/static/js/padiem-cinematic-worlds-v1.js
@@ -121,7 +121,8 @@
     if (!overlay || !DRAWER[language][key]) return;
     activeDrawerTab = key;
     const data = DRAWER[language][key];
-    overlay.dataset.panel = key;
+    const cssPanel = key === 'company' ? 'about' : key === 'contact' ? 'inquiry' : 'team';
+    overlay.dataset.panel = cssPanel;
     overlay.style.setProperty('--overlay-accent-rgb', key === 'contact' ? '143,207,255' : key === 'team' ? '153,194,229' : '228,188,116');
     overlayKicker.textContent = data.kicker;
     overlayTitle.textContent = data.title;

--- a/static/js/padiem-cinematic-worlds-v1.js
+++ b/static/js/padiem-cinematic-worlds-v1.js
@@ -1,0 +1,172 @@
+(() => {
+  const progress = document.querySelector('[data-world-progress]');
+  const reduced = matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+  const updateProgress = () => {
+    if (!progress) return;
+    const max = Math.max(1, document.documentElement.scrollHeight - innerHeight);
+    progress.style.transform = `scaleX(${Math.min(1, Math.max(0, scrollY / max))})`;
+  };
+  addEventListener('scroll', updateProgress, { passive: true });
+  addEventListener('resize', updateProgress);
+  updateProgress();
+
+  const revealEls = [...document.querySelectorAll('.reveal')];
+  if (reduced || !('IntersectionObserver' in window)) {
+    revealEls.forEach(el => el.classList.add('visible'));
+  } else {
+    const observer = new IntersectionObserver(entries => {
+      entries.forEach(entry => {
+        if (!entry.isIntersecting) return;
+        entry.target.style.transitionDelay = `${entry.target.dataset.delay || 0}ms`;
+        entry.target.classList.add('visible');
+        observer.unobserve(entry.target);
+      });
+    }, { threshold: .12 });
+    revealEls.forEach(el => observer.observe(el));
+  }
+
+  const DRAWER = {
+    ko: {
+      company: {
+        kicker: 'COMPANY / 01',
+        title: '주식회사 파디엠',
+        lead: '기술을 나열하는 데서 멈추지 않고, 산업과 공공의 실제 업무를 사람이 체감하는 AI 시스템으로 바꿉니다.',
+        paragraphs: [
+          '파디엠은 2016년 Safety IoT 기술에서 출발해 2018년 법인을 설립하고, 음성·언어 AI, Vision·Multimodal AI, Generative AI·AX, Public AI Agent로 기술 영역을 확장해왔습니다.',
+          '제품, 인터랙션, 운영 구조를 따로 보지 않고 하나의 실행 경험으로 설계하는 것이 파디엠의 핵심 방식입니다.'
+        ],
+        items: ['Safety IoT · Public Safety', 'Speech · Language AI', 'Vision · Multimodal AI', 'Generative AI · AX', 'Public AI Agent']
+      },
+      team: {
+        kicker: 'COMPANY / 02',
+        title: 'Team',
+        lead: '기술, 제품, 디자인과 현장 문제를 하나의 흐름으로 연결하는 멀티디시플린 팀.',
+        paragraphs: [
+          '파디엠의 공개 사이트에서는 개인 경력의 나열보다 어떤 문제를 어떤 방식으로 해결하는지가 먼저 보이도록 합니다.',
+          '리더십 상세 프로필은 검증된 공개 정보만 사용하며 별도 승인 없이 새로운 수치·경력·성과를 만들어내지 않습니다.'
+        ],
+        items: ['Product & Business', 'AI & Software', 'Interaction Design', 'Public / Field Operations']
+      },
+      contact: {
+        kicker: 'COMPANY / 03',
+        title: 'Project Inquiry',
+        lead: '현재 해결하려는 업무와 문제를 알려주시면 적용 가능한 AI 방식부터 함께 검토합니다.',
+        paragraphs: ['기업 AI 도입, 공공 AI 서비스, 맞춤형 기술 개발, AI 교육·컨설팅, 사업 제휴를 검토합니다.'],
+        items: ['기업 AI 도입', '공공 AI 서비스', '맞춤형 기술 개발', 'AI 교육·컨설팅', '사업 제휴'],
+        email: 'ceo@padiem.net'
+      }
+    },
+    en: {
+      company: {
+        kicker: 'COMPANY / 01',
+        title: 'PADIEM Co., Ltd.',
+        lead: 'We turn real workflows across industry and the public sector into AI systems people can actually experience and use.',
+        paragraphs: [
+          'PADIEM began with Safety IoT in 2016, incorporated in 2018, and expanded into speech and language AI, vision and multimodal AI, generative AI and AX, and public AI agents.',
+          'Our core method is to design product, interaction and operational structure as one execution experience.'
+        ],
+        items: ['Safety IoT · Public Safety', 'Speech · Language AI', 'Vision · Multimodal AI', 'Generative AI · AX', 'Public AI Agent']
+      },
+      team: {
+        kicker: 'COMPANY / 02',
+        title: 'Team',
+        lead: 'A multidisciplinary team connecting technology, product, design and field problems in one flow.',
+        paragraphs: [
+          'Our public site prioritizes how we solve problems over a long list of credentials.',
+          'Leadership details use verified public information only; no new metrics or claims are introduced without authority.'
+        ],
+        items: ['Product & Business', 'AI & Software', 'Interaction Design', 'Public / Field Operations']
+      },
+      contact: {
+        kicker: 'COMPANY / 03',
+        title: 'Project Inquiry',
+        lead: 'Tell us the workflow or problem you are trying to solve, and we will review a practical AI approach with you.',
+        paragraphs: ['We review enterprise AI adoption, public AI services, custom technology development, AI training and consulting, and partnerships.'],
+        items: ['Enterprise AI Adoption', 'Public AI Services', 'Custom Technology Development', 'AI Training & Consulting', 'Partnerships'],
+        email: 'ceo@padiem.net'
+      }
+    }
+  };
+
+  const langButtons = [...document.querySelectorAll('[data-world-lang]')];
+  let language = localStorage.getItem('padiem-language') || (/^ko/i.test(navigator.language || '') ? 'ko' : 'en');
+  if (!DRAWER[language]) language = 'ko';
+
+  const applyLanguage = next => {
+    if (!DRAWER[next]) return;
+    language = next;
+    localStorage.setItem('padiem-language', next);
+    document.documentElement.lang = next;
+    document.body.dataset.lang = next;
+    langButtons.forEach(button => button.setAttribute('aria-pressed', String(button.dataset.worldLang === next)));
+    document.querySelectorAll('[data-copy-ko][data-copy-en]').forEach(element => {
+      const value = next === 'ko' ? element.dataset.copyKo : element.dataset.copyEn;
+      if (value) element.textContent = value;
+    });
+    if (overlay && !overlay.hidden) renderDrawer(activeDrawerTab);
+  };
+  langButtons.forEach(button => button.addEventListener('click', () => applyLanguage(button.dataset.worldLang)));
+
+  const overlay = document.getElementById('worldCompanyOverlay');
+  const overlayKicker = document.getElementById('worldDrawerKicker');
+  const overlayTitle = document.getElementById('worldDrawerTitle');
+  const overlayLead = document.getElementById('worldDrawerLead');
+  const overlayBody = document.getElementById('worldDrawerBody');
+  const closeButton = overlay?.querySelector('[data-world-drawer-close]');
+  let activeDrawerTab = 'company';
+  let lastTrigger = null;
+
+  const renderDrawer = key => {
+    if (!overlay || !DRAWER[language][key]) return;
+    activeDrawerTab = key;
+    const data = DRAWER[language][key];
+    overlay.dataset.panel = key;
+    overlay.style.setProperty('--overlay-accent-rgb', key === 'contact' ? '143,207,255' : key === 'team' ? '153,194,229' : '228,188,116');
+    overlayKicker.textContent = data.kicker;
+    overlayTitle.textContent = data.title;
+    overlayLead.textContent = data.lead;
+    const tabs = `<div class="world-drawer-tabs" role="tablist" aria-label="Company sections">
+      ${['company','team','contact'].map(tab => `<button type="button" data-world-drawer-tab="${tab}" aria-pressed="${String(tab === key)}">${tab.toUpperCase()}</button>`).join('')}
+    </div>`;
+    const paragraphs = data.paragraphs.map(text => `<p>${text}</p>`).join('');
+    const list = `<ul class="world-drawer-list">${data.items.map(item => `<li>${item}</li>`).join('')}</ul>`;
+    const email = data.email ? `<a class="world-drawer-link" href="mailto:${data.email}">${data.email}</a>` : '';
+    overlayBody.innerHTML = `${tabs}<div class="world-drawer-copy">${paragraphs}${list}${email}</div>`;
+  };
+
+  const openDrawer = trigger => {
+    if (!overlay) return;
+    lastTrigger = trigger || null;
+    renderDrawer('company');
+    overlay.hidden = false;
+    overlay.setAttribute('aria-hidden', 'false');
+    document.body.classList.add('overlay-open');
+    closeButton?.focus();
+  };
+  const closeDrawer = () => {
+    if (!overlay) return;
+    overlay.hidden = true;
+    overlay.setAttribute('aria-hidden', 'true');
+    document.body.classList.remove('overlay-open');
+    lastTrigger?.focus();
+  };
+
+  document.querySelectorAll('[data-world-drawer="company"]').forEach(trigger => trigger.addEventListener('click', event => {
+    event.preventDefault();
+    openDrawer(trigger);
+  }));
+  overlay?.addEventListener('click', event => {
+    const tab = event.target.closest('[data-world-drawer-tab]');
+    if (tab) {
+      renderDrawer(tab.dataset.worldDrawerTab);
+      return;
+    }
+    if (event.target.closest('[data-world-drawer-close]')) closeDrawer();
+  });
+  addEventListener('keydown', event => {
+    if (event.key === 'Escape' && overlay && !overlay.hidden) closeDrawer();
+  });
+
+  applyLanguage(language);
+})();

--- a/static/js/padiem-home-drawer-tabs-v1.js
+++ b/static/js/padiem-home-drawer-tabs-v1.js
@@ -1,0 +1,53 @@
+(() => {
+  const overlay = document.getElementById('overlay');
+  const body = document.getElementById('overlayBody');
+  if (!overlay || !body) return;
+
+  const labels = {
+    ko: { about: 'COMPANY', team: 'TEAM', inquiry: 'CONTACT' },
+    en: { about: 'COMPANY', team: 'TEAM', inquiry: 'CONTACT' }
+  };
+  const triggerIds = {
+    about: 'padiemDrawerCompanyTrigger',
+    team: 'padiemDrawerTeamTrigger',
+    inquiry: 'padiemDrawerContactTrigger'
+  };
+
+  const language = () => document.body.dataset.lang === 'en' ? 'en' : 'ko';
+
+  const injectTabs = () => {
+    const panel = overlay.dataset.panel;
+    if (!['about', 'team', 'inquiry'].includes(panel)) return;
+    if (body.querySelector('.padiem-company-drawer-tabs')) return;
+
+    const nav = document.createElement('div');
+    nav.className = 'padiem-company-drawer-tabs';
+    nav.setAttribute('role', 'tablist');
+    nav.setAttribute('aria-label', 'Company sections');
+    nav.innerHTML = ['about', 'team', 'inquiry'].map(key => (
+      `<button type="button" data-company-panel="${key}" aria-pressed="${String(key === panel)}">${labels[language()][key]}</button>`
+    )).join('');
+    body.prepend(nav);
+  };
+
+  overlay.addEventListener('click', event => {
+    const button = event.target.closest('[data-company-panel]');
+    if (!button) return;
+    const trigger = document.getElementById(triggerIds[button.dataset.companyPanel]);
+    trigger?.click();
+  });
+
+  const observer = new MutationObserver(injectTabs);
+  observer.observe(body, { childList: true, subtree: false });
+  const panelObserver = new MutationObserver(injectTabs);
+  panelObserver.observe(overlay, { attributes: true, attributeFilter: ['data-panel'] });
+  injectTabs();
+
+  const style = document.createElement('style');
+  style.textContent = `
+    .padiem-company-drawer-tabs{display:flex;gap:7px;flex-wrap:wrap;margin:0 0 22px;}
+    .padiem-company-drawer-tabs button{border:1px solid rgba(35,63,86,.16);border-radius:999px;background:rgba(255,255,255,.23);color:rgba(17,42,62,.66);padding:8px 11px;font-family:var(--font-label);font-size:9px;letter-spacing:.12em;cursor:pointer;}
+    .padiem-company-drawer-tabs button[aria-pressed="true"]{background:#17354e;color:#fff;border-color:#17354e;}
+  `;
+  document.head.appendChild(style);
+})();

--- a/static/js/padiem-home-nav-v1.js
+++ b/static/js/padiem-home-nav-v1.js
@@ -15,6 +15,75 @@
   configure(links[3], 'Design', '/design/');
   configure(links[4], 'Company', '#company', 'about');
 
+  // Mobile keeps the exact same IA, but expresses it as a pearl/glass bottom
+  // sheet instead of hiding the primary destinations below 760px.
+  const navInner = document.querySelector('.nav-inner');
+  const chatCta = document.querySelector('.nav-cta');
+  if (navInner && chatCta) {
+    const menuButton = document.createElement('button');
+    menuButton.type = 'button';
+    menuButton.className = 'home-mobile-menu-toggle';
+    menuButton.setAttribute('aria-expanded', 'false');
+    menuButton.setAttribute('aria-controls', 'homeMobileMenu');
+    menuButton.setAttribute('aria-label', 'Open PADIEM menu');
+    menuButton.innerHTML = '<span class="home-mobile-menu-toggle-lines" aria-hidden="true"></span><span class="home-mobile-menu-toggle-text">MENU</span>';
+    navInner.insertBefore(menuButton, chatCta);
+
+    const menu = document.createElement('div');
+    menu.id = 'homeMobileMenu';
+    menu.className = 'home-mobile-menu';
+    menu.hidden = true;
+    menu.setAttribute('aria-hidden', 'true');
+    menu.innerHTML = `
+      <div class="home-mobile-menu-backdrop" data-home-mobile-close></div>
+      <section class="home-mobile-menu-panel" role="dialog" aria-modal="true" aria-label="PADIEM navigation">
+        <div class="home-mobile-menu-meta"><strong>PADIEM</strong><span>Navigation / 2026</span></div>
+        <nav class="home-mobile-menu-links" aria-label="Mobile navigation">
+          <a class="home-mobile-menu-link" href="#solutions"><span class="home-mobile-menu-index">01</span><span class="home-mobile-menu-label">Solutions</span><span class="home-mobile-menu-arrow">↓</span></a>
+          <a class="home-mobile-menu-link" href="#evolution"><span class="home-mobile-menu-index">02</span><span class="home-mobile-menu-label">Evolution</span><span class="home-mobile-menu-arrow">↓</span></a>
+          <a class="home-mobile-menu-link" href="/products/"><span class="home-mobile-menu-index">03</span><span class="home-mobile-menu-label">Products</span><span class="home-mobile-menu-arrow">↗</span></a>
+          <a class="home-mobile-menu-link" href="/design/"><span class="home-mobile-menu-index">04</span><span class="home-mobile-menu-label">Design</span><span class="home-mobile-menu-arrow">↗</span></a>
+          <a class="home-mobile-menu-link" href="#company" data-overlay="about"><span class="home-mobile-menu-index">05</span><span class="home-mobile-menu-label">Company</span><span class="home-mobile-menu-arrow">→</span></a>
+        </nav>
+        <div class="home-mobile-menu-foot"><span>Scroll narrative · cinematic worlds</span><span>Concept → System → Field</span></div>
+      </section>`;
+    document.body.appendChild(menu);
+
+    let lastFocused = null;
+    const closeMobileMenu = ({ restoreFocus = true } = {}) => {
+      if (menu.hidden) return;
+      menu.hidden = true;
+      menu.setAttribute('aria-hidden', 'true');
+      menuButton.setAttribute('aria-expanded', 'false');
+      document.body.classList.remove('home-mobile-menu-open');
+      if (restoreFocus) (lastFocused || menuButton).focus();
+    };
+    const openMobileMenu = () => {
+      lastFocused = document.activeElement;
+      menu.hidden = false;
+      menu.setAttribute('aria-hidden', 'false');
+      menuButton.setAttribute('aria-expanded', 'true');
+      document.body.classList.add('home-mobile-menu-open');
+      menu.querySelector('.home-mobile-menu-link')?.focus();
+    };
+
+    menuButton.addEventListener('click', () => {
+      if (menu.hidden) openMobileMenu();
+      else closeMobileMenu();
+    });
+    menu.querySelectorAll('[data-home-mobile-close]').forEach(element => element.addEventListener('click', () => closeMobileMenu()));
+    menu.querySelectorAll('.home-mobile-menu-link').forEach(element => element.addEventListener('click', () => closeMobileMenu({ restoreFocus: false })));
+    addEventListener('keydown', event => {
+      if (event.key === 'Escape' && !menu.hidden) {
+        event.preventDefault();
+        closeMobileMenu();
+      }
+    });
+    addEventListener('resize', () => {
+      if (innerWidth > 760 && !menu.hidden) closeMobileMenu({ restoreFocus: false });
+    });
+  }
+
   // Hidden triggers keep Team and Contact inside the existing first-party
   // pearl drawer system without exposing them as competing top-level routes.
   const hiddenHost = document.createElement('div');

--- a/static/js/padiem-home-nav-v1.js
+++ b/static/js/padiem-home-nav-v1.js
@@ -26,4 +26,18 @@
     '<button type="button" id="padiemDrawerContactTrigger" data-overlay="inquiry"></button>'
   ].join('');
   document.body.appendChild(hiddenHost);
+
+  const requestedPanel = new URLSearchParams(location.search).get('panel');
+  const panelTrigger = {
+    company: 'padiemDrawerCompanyTrigger',
+    team: 'padiemDrawerTeamTrigger',
+    contact: 'padiemDrawerContactTrigger'
+  }[requestedPanel];
+
+  // This script executes immediately before the existing overlay runtime.
+  // Defer the synthetic click until the current script stack has completed so
+  // the original runtime has bound its data-overlay listeners first.
+  if (panelTrigger) {
+    setTimeout(() => document.getElementById(panelTrigger)?.click(), 0);
+  }
 })();

--- a/static/js/padiem-home-nav-v1.js
+++ b/static/js/padiem-home-nav-v1.js
@@ -1,0 +1,29 @@
+(() => {
+  const links = [...document.querySelectorAll('.nav-links > a.nav-link')];
+  if (links.length < 5) return;
+
+  const configure = (element, label, href, overlay = null) => {
+    element.textContent = label;
+    element.href = href;
+    element.removeAttribute('data-overlay');
+    if (overlay) element.dataset.overlay = overlay;
+  };
+
+  configure(links[0], 'Solutions', '#solutions');
+  configure(links[1], 'Evolution', '#evolution');
+  configure(links[2], 'Products', '/products/');
+  configure(links[3], 'Design', '/design/');
+  configure(links[4], 'Company', '#company', 'about');
+
+  // Hidden triggers keep Team and Contact inside the existing first-party
+  // pearl drawer system without exposing them as competing top-level routes.
+  const hiddenHost = document.createElement('div');
+  hiddenHost.hidden = true;
+  hiddenHost.setAttribute('aria-hidden', 'true');
+  hiddenHost.innerHTML = [
+    '<button type="button" id="padiemDrawerCompanyTrigger" data-overlay="about"></button>',
+    '<button type="button" id="padiemDrawerTeamTrigger" data-overlay="team"></button>',
+    '<button type="button" id="padiemDrawerContactTrigger" data-overlay="inquiry"></button>'
+  ].join('');
+  document.body.appendChild(hiddenHost);
+})();

--- a/static/js/padiem-scroll-scrub-v1.js
+++ b/static/js/padiem-scroll-scrub-v1.js
@@ -1,0 +1,126 @@
+(() => {
+  const DEFAULT_VIDEO = 'https://d8j0ntlcm91z4.cloudfront.net/user_38xzZboKViGWJOttwIXH07lWA1P/hf_20260729_102822_0e6c87e8-c141-4744-bf32-ad30db296371.mp4';
+  const videoUrl = document.body.dataset.worldScrollVideo || DEFAULT_VIDEO;
+  if (!videoUrl) return;
+
+  const reduced = matchMedia('(prefers-reduced-motion: reduce)').matches;
+  const clamp = (value, min, max) => Math.min(max, Math.max(min, value));
+
+  const style = document.createElement('style');
+  style.dataset.padiemScrollScrub = 'v1';
+  style.textContent = `
+    .world-scroll-video-layer{
+      position:fixed;
+      inset:0;
+      z-index:0;
+      overflow:hidden;
+      pointer-events:none;
+      background:#06080d;
+    }
+    .world-scroll-video-layer video,
+    .world-scroll-video-poster,
+    .world-scroll-video-tone,
+    .world-scroll-video-vignette{
+      position:absolute;
+      inset:0;
+      width:100%;
+      height:100%;
+    }
+    .world-scroll-video-layer video{
+      object-fit:cover;
+      opacity:0;
+      filter:saturate(.72) contrast(1.06) brightness(.72);
+      transform:scale(1.018);
+      transition:opacity .6s ease;
+    }
+    .world-scroll-video-poster{
+      background:
+        radial-gradient(circle at 62% 42%,rgba(183,213,255,.17),transparent 24%),
+        radial-gradient(circle at 37% 61%,rgba(239,201,132,.10),transparent 26%),
+        linear-gradient(140deg,#07101a 0%,#07090e 52%,#020305 100%);
+      transition:opacity .6s ease;
+    }
+    .world-scroll-video-tone{
+      background:
+        linear-gradient(180deg,rgba(2,8,18,.46) 0%,rgba(3,6,12,.16) 42%,rgba(2,4,8,.62) 100%),
+        radial-gradient(circle at 18% 50%,rgba(12,44,82,.22),transparent 38%),
+        radial-gradient(circle at 82% 50%,rgba(103,60,12,.10),transparent 36%);
+      mix-blend-mode:multiply;
+    }
+    .world-scroll-video-vignette{
+      box-shadow:inset 0 0 220px 76px rgba(0,0,0,.56);
+      background:linear-gradient(90deg,rgba(1,4,9,.24),transparent 28%,transparent 70%,rgba(1,4,9,.22));
+    }
+    body.world-body > .world-page{position:relative;z-index:10;}
+    @media (prefers-reduced-motion: reduce){
+      .world-scroll-video-layer video{display:none;}
+    }
+  `;
+  document.head.appendChild(style);
+
+  const layer = document.createElement('div');
+  layer.className = 'world-scroll-video-layer';
+  layer.setAttribute('aria-hidden', 'true');
+  layer.innerHTML = `
+    <div class="world-scroll-video-poster"></div>
+    <video muted playsinline preload="metadata" crossorigin="anonymous"></video>
+    <div class="world-scroll-video-tone"></div>
+    <div class="world-scroll-video-vignette"></div>
+  `;
+  document.body.prepend(layer);
+
+  const video = layer.querySelector('video');
+  const poster = layer.querySelector('.world-scroll-video-poster');
+  let target = 0;
+  let smoothed = 0;
+  let ready = false;
+
+  const updateTarget = () => {
+    const max = Math.max(1, document.documentElement.scrollHeight - innerHeight);
+    target = clamp(scrollY / max, 0, 1);
+    document.documentElement.style.setProperty('--padiem-scroll-progress', target.toFixed(4));
+  };
+
+  addEventListener('scroll', updateTarget, { passive: true });
+  addEventListener('resize', updateTarget);
+  updateTarget();
+
+  video.crossOrigin = 'anonymous';
+  video.muted = true;
+  video.playsInline = true;
+  video.preload = 'metadata';
+  video.src = videoUrl;
+
+  video.addEventListener('loadedmetadata', () => {
+    try { video.currentTime = 0.01; } catch {}
+  }, { once: true });
+
+  video.addEventListener('loadeddata', () => {
+    ready = true;
+    video.style.opacity = '.72';
+    poster.style.opacity = '.18';
+  }, { once: true });
+
+  video.addEventListener('error', () => {
+    ready = false;
+    video.style.opacity = '0';
+    poster.style.opacity = '1';
+  }, { once: true });
+
+  video.load();
+
+  if (reduced) return;
+
+  const frame = () => {
+    smoothed += (target - smoothed) * 0.14;
+    if (ready && video.readyState >= 2 && Number.isFinite(video.duration) && video.duration > 0) {
+      const desired = smoothed * Math.max(0, video.duration - 0.05);
+      if (Math.abs(video.currentTime - desired) > 0.075 && !video.seeking) {
+        try { video.currentTime = desired; } catch {}
+      }
+    }
+    requestAnimationFrame(frame);
+  };
+
+  frame();
+})();


### PR DESCRIPTION
## PADIEM Cinematic Worlds — Local Build/Render QA

QA-only verification of the cinematic worlds branch. No layouts, copy, or design decisions were changed. Build is clean; all functional checks pass. Opened as **Draft** for review — **do not merge or deploy** without sign-off.

- **Branch:** `design/padiem-cinematic-worlds-v1`
- **HEAD reviewed:** `c555adc950028728db334f47c1833c4e2f92d3a6`
- **Base:** `main` (`c9029146`)
- **Diff vs main:** 13 files, source-only (`static/`, `scripts/`, `docs/`, `sitemap.xml`, `_redirects`, `README`) — no `public/` build artifacts committed.

### Build
- `node scripts/build-cinematic-site.mjs` → `Built canonical PADIEM cinematic site and worlds.` ✅
- Build wipes `public/` and regenerates from `static/` (Netlify `command` + `publish = "public"`), so committed `public/` is vestigial and deploy is self-sufficient.
- Generated outputs present: `public/index.html`, `public/products/index.html`, `public/design/index.html`. ✅
- Correctly absent: `public/about/index.html`, `public/contact/index.html`, `public/html/pages/**` legacy tree. ✅
- `git diff --check`: no whitespace errors (new commits + full branch). ✅

### Static content (rendered DOM)
- Home nav (runtime-rewritten by `padiem-home-nav-v1.js`): `Solutions, Evolution, Products, Design, Company` ✅
- Padiem Chat CTA on all 3 pages → `https://chat.padiem.net/` ✅
- Old worker URL `padiem-chat.charliekant.workers.dev`: **0 matches** ✅
- Legacy header text `PadiemAI`: **0 matches** ✅
- Products: 5/5 items (Padiem Chat, StoryMemory, LoveTree, 단지온, AI 무료 레이더) ✅
- Design: 4/4 main + 3/3 archive (3D 기억책장, 로테이팅 메모리 인덱스, 모먼트 리빌) ✅

### Interactions (Playwright, headless)
- Home: Solutions→`#solutions`, Evolution→`#evolution` scroll ✅; Company drawer opens ✅; TEAM/CONTACT tabs ✅; Escape closes ✅
- Products/Design: `data-world-drawer` opens ✅; TEAM/CONTACT `data-world-drawer-tab` ✅
- **New scroll-scrub runtime** (`padiem-scroll-scrub-v1.js`, injected into worlds pages): layer + video + poster + injected style present; `--padiem-scroll-progress` tracks scroll (0 → 0.60); **0 JS errors** on `/products/` and `/design/`; graceful poster fallback on video error. Home intentionally excluded. ✅
- Compatibility: `/about/`,`/team/`,`/contact/` → `?panel=company|team|contact` `_redirects` rules present ✅; `?panel=` routes open the correct drawer (company/team/contact) ✅ (note: `_redirects` requires Netlify runtime; verified via direct `?panel=` params locally).

### Responsive
- Desktop 1440×900: no horizontal overflow (home/products/design) ✅
- Mobile 390×844: no horizontal overflow (home/products/design) ✅; drawer + TEAM tab reachable via `?panel=company` ✅

### Notes for CENTRAL (non-blocking, no action taken)
1. **Home mobile nav (pre-existing, not from this branch):** at 390px `static/css/padiem-cinematic-v2-4.css` sets `.nav-links{display:none}` with no hamburger toggle, so Products/Design/Company are not reachable from the home header on mobile (only KO/EN + Chat CTA). This file is unchanged vs `main`. The worlds pages added by this branch *do* have a mobile scrollable nav (`worlds-v1.css:200`). Flagging only — left as-is per QA-only scope.
2. Local QA evidence (screenshots + `qa-results.json`) lives in `public/.qascreenshots/` as untracked working-tree artifacts — not committed and not part of this PR.

### Disposition
Build clean, all functional/responsive/interaction checks pass, PR diff is source-only. **Ready for design review.** Awaiting explicit approval before merge/production deploy.
