### PR TITLE
[SUPERSEDED by #28] feat(design): prepare gated video exhibit runtime

### DIFF
--- a/scripts/build-cinematic-site.mjs
+++ b/scripts/build-cinematic-site.mjs
@@ -29,6 +29,8 @@ const worldScrubScript = '<script src="/js/padiem-scroll-scrub-v1.js"></script>'
 const homeMobileNavStyle = '<link rel="stylesheet" href="/css/padiem-home-mobile-nav-v1.css"/>';
 const liveExhibitStyle = '<link rel="stylesheet" href="/css/padiem-live-exhibits-v1.css"/>';
 const liveExhibitScript = '<script src="/js/padiem-live-exhibits-v1.js"></script>';
+const designVideoStyle = '<link rel="stylesheet" href="/css/padiem-design-video-v1.css"/>';
+const designVideoScript = '<script src="/js/padiem-design-video-v1.js"></script>';
 const productExhibitStyle = '<link rel="stylesheet" href="/css/padiem-product-exhibits-v1.css"/>';
 const productExhibitScript = '<script src="/js/padiem-product-exhibits-v1.js"></script>';
 
@@ -122,7 +124,7 @@ for (const { source, dest } of showcasePages) {
   }
 
   // Products and Design are separate exhibition worlds. Each receives only its
-  // own public-safe study runtime while sharing the same cinematic scroll-scrub.
+  // own public-safe runtime while sharing the same cinematic scroll-scrub.
   if (source === 'pages/products.html') {
     if (!pageHtml.includes('padiem-product-exhibits-v1.css')) {
       pageHtml = pageHtml.replace('</head>', `  ${productExhibitStyle}\n</head>`);
@@ -133,11 +135,26 @@ for (const { source, dest } of showcasePages) {
   }
 
   if (source === 'pages/design.html') {
-    if (!pageHtml.includes('padiem-live-exhibits-v1.css')) {
-      pageHtml = pageHtml.replace('</head>', `  ${liveExhibitStyle}\n</head>`);
-    }
-    if (!pageHtml.includes('padiem-live-exhibits-v1.js')) {
-      pageHtml = pageHtml.replace('</body>', `  ${liveExhibitScript}\n</body>`);
+    // Until an approved media integration explicitly marks a frame with
+    // data-padiem-design-video, production keeps the current first-party
+    // interaction studies. This makes the video runtime inert by default and
+    // prevents accidental publication of unapproved external media URLs.
+    const designVideoEnabled = pageHtml.includes('data-padiem-design-video');
+
+    if (designVideoEnabled) {
+      if (!pageHtml.includes('padiem-design-video-v1.css')) {
+        pageHtml = pageHtml.replace('</head>', `  ${designVideoStyle}\n</head>`);
+      }
+      if (!pageHtml.includes('padiem-design-video-v1.js')) {
+        pageHtml = pageHtml.replace('</body>', `  ${designVideoScript}\n</body>`);
+      }
+    } else {
+      if (!pageHtml.includes('padiem-live-exhibits-v1.css')) {
+        pageHtml = pageHtml.replace('</head>', `  ${liveExhibitStyle}\n</head>`);
+      }
+      if (!pageHtml.includes('padiem-live-exhibits-v1.js')) {
+        pageHtml = pageHtml.replace('</body>', `  ${liveExhibitScript}\n</body>`);
+      }
     }
   }
 

--- a/scripts/build-cinematic-site.mjs
+++ b/scripts/build-cinematic-site.mjs
@@ -135,13 +135,44 @@ for (const { source, dest } of showcasePages) {
   }
 
   if (source === 'pages/design.html') {
-    // Until an approved media integration explicitly marks a frame with
-    // data-padiem-design-video, production keeps the current first-party
-    // interaction studies. This makes the video runtime inert by default and
-    // prevents accidental publication of unapproved external media URLs.
-    const designVideoEnabled = pageHtml.includes('data-padiem-design-video');
+    // Until an approved media integration explicitly marks all four Design
+    // frames, production keeps the current first-party interaction studies.
+    // Once activated, fail closed on partial rollout, direct r2.dev exposure,
+    // cache-busting query strings, or non-versioned/non-canonical media URLs.
+    const designVideoMarkerCount = (pageHtml.match(/data-padiem-design-video/g) || []).length;
+    if (designVideoMarkerCount !== 0 && designVideoMarkerCount !== 4) {
+      throw new Error(`Design video integration must mark exactly four frames; found ${designVideoMarkerCount}.`);
+    }
+
+    const designVideoEnabled = designVideoMarkerCount === 4;
+    const designVideoSrcMatches = [...pageHtml.matchAll(/data-video-src="([^"]+)"/g)].map(match => match[1]);
+
+    if (!designVideoEnabled && designVideoSrcMatches.length) {
+      throw new Error("Design video sources exist without the four-frame activation marker.");
+    }
 
     if (designVideoEnabled) {
+      if (designVideoSrcMatches.length !== 4) {
+        throw new Error(`Design video integration requires exactly four source URLs; found ${designVideoSrcMatches.length}.`);
+      }
+      if (pageHtml.includes('.r2.dev')) {
+        throw new Error("Direct r2.dev media URLs are forbidden in the production Design page.");
+      }
+
+      for (const src of designVideoSrcMatches) {
+        const url = new URL(src);
+        const versionedMp4 = /-v\d+\.mp4$/i.test(url.pathname);
+        if (url.origin !== 'https://media.padiem.net' || !url.pathname.startsWith('/design/')) {
+          throw new Error(`Design media must use https://media.padiem.net/design/: ${src}`);
+        }
+        if (url.search || url.hash) {
+          throw new Error(`Design media URLs must not use query strings or fragments: ${src}`);
+        }
+        if (!versionedMp4) {
+          throw new Error(`Design media filename must be versioned and end in -vN.mp4: ${src}`);
+        }
+      }
+
       if (!pageHtml.includes('padiem-design-video-v1.css')) {
         pageHtml = pageHtml.replace('</head>', `  ${designVideoStyle}\n</head>`);
       }

--- a/static/css/padiem-design-video-v1.css
+++ b/static/css/padiem-design-video-v1.css
@@ -1,0 +1,16 @@
+/* PADIEM Design video runtime v1.
+   This stylesheet is inert until a Design frame carries data-padiem-design-video.
+   The existing first-party frame content remains the independent fallback. */
+
+[data-padiem-design-video]{position:relative;isolation:isolate}
+[data-padiem-design-video]>.padiem-design-video{position:absolute;inset:0;z-index:6;width:100%;height:100%;object-fit:cover;border-radius:inherit;background:#05070a;opacity:0;pointer-events:none;transition:opacity .45s ease}
+[data-padiem-design-video][data-video-state="ready"]>.padiem-design-video,
+[data-padiem-design-video][data-video-state="playing"]>.padiem-design-video,
+[data-padiem-design-video][data-video-state="paused"]>.padiem-design-video{opacity:1}
+[data-padiem-design-video][data-video-state="loading"]::after{content:"MEDIA / LOADING";position:absolute;z-index:7;right:14px;bottom:12px;font-family:var(--font-label);font-size:7px;letter-spacing:.14em;color:rgba(255,255,255,.44);pointer-events:none}
+[data-padiem-design-video][data-video-state="fallback"]>.padiem-design-video,
+[data-padiem-design-video][data-video-state="idle"]>.padiem-design-video{opacity:0}
+
+@media(prefers-reduced-motion:reduce){
+  [data-padiem-design-video]>.padiem-design-video{display:none!important}
+}

--- a/static/js/padiem-design-video-v1.js
+++ b/static/js/padiem-design-video-v1.js
@@ -1,0 +1,128 @@
+(() => {
+  const mounts = [...document.querySelectorAll('[data-padiem-design-video]')];
+  if (!mounts.length || !document.title.includes('PADIEM Design')) return;
+
+  const reducedMotion = matchMedia('(prefers-reduced-motion: reduce)').matches;
+  const records = new Map();
+
+  const setState = (mount, state) => {
+    mount.dataset.videoState = state;
+  };
+
+  const ensureVideo = mount => {
+    if (records.has(mount)) return records.get(mount);
+
+    const src = mount.dataset.videoSrc?.trim();
+    if (!src) {
+      setState(mount, 'fallback');
+      return null;
+    }
+
+    const video = document.createElement('video');
+    video.className = 'padiem-design-video';
+    video.muted = true;
+    video.defaultMuted = true;
+    video.loop = true;
+    video.playsInline = true;
+    video.preload = 'none';
+    video.controls = false;
+    video.disablePictureInPicture = true;
+    video.setAttribute('aria-hidden', 'true');
+    video.setAttribute('tabindex', '-1');
+
+    const record = {
+      mount,
+      video,
+      src,
+      sourceAttached: false,
+      failed: false,
+      inView: false,
+    };
+
+    video.addEventListener('loadeddata', () => {
+      if (record.failed) return;
+      setState(mount, 'ready');
+      if (record.inView && !document.hidden && !reducedMotion) {
+        video.play().catch(() => setState(mount, 'paused'));
+      }
+    });
+
+    video.addEventListener('playing', () => {
+      if (!record.failed) setState(mount, 'playing');
+    });
+
+    video.addEventListener('pause', () => {
+      if (!record.failed && mount.dataset.videoState !== 'fallback') {
+        setState(mount, 'paused');
+      }
+    });
+
+    const failOpen = () => {
+      record.failed = true;
+      video.pause();
+      video.removeAttribute('src');
+      video.load();
+      video.remove();
+      setState(mount, 'fallback');
+    };
+
+    video.addEventListener('error', failOpen, { once: true });
+    video.addEventListener('abort', () => {
+      if (!record.failed && !record.inView) setState(mount, 'paused');
+    });
+
+    mount.append(video);
+    setState(mount, reducedMotion ? 'fallback' : 'idle');
+    records.set(mount, record);
+    return record;
+  };
+
+  const attachSource = record => {
+    if (!record || record.sourceAttached || record.failed || reducedMotion) return;
+    record.video.src = record.src;
+    record.video.preload = 'metadata';
+    record.sourceAttached = true;
+    setState(record.mount, 'loading');
+    record.video.load();
+  };
+
+  const play = record => {
+    if (!record || record.failed || reducedMotion || document.hidden) return;
+    attachSource(record);
+    if (record.video.readyState >= 2) {
+      record.video.play().catch(() => setState(record.mount, 'paused'));
+    }
+  };
+
+  const pause = record => {
+    if (!record || record.failed) return;
+    record.video.pause();
+  };
+
+  mounts.forEach(ensureVideo);
+
+  if (reducedMotion) return;
+
+  const observer = new IntersectionObserver(entries => {
+    entries.forEach(entry => {
+      const record = records.get(entry.target);
+      if (!record) return;
+      record.inView = entry.isIntersecting && entry.intersectionRatio >= 0.2;
+      if (record.inView) play(record);
+      else pause(record);
+    });
+  }, {
+    root: null,
+    rootMargin: '180px 0px',
+    threshold: [0, 0.2, 0.55],
+  });
+
+  records.forEach(record => observer.observe(record.mount));
+
+  document.addEventListener('visibilitychange', () => {
+    records.forEach(record => {
+      if (document.hidden) pause(record);
+      else if (record.inView) play(record);
+    });
+  });
+})();

--- a/static/js/padiem-design-video-v1.js
+++ b/static/js/padiem-design-video-v1.js
@@ -2,18 +2,38 @@
   const mounts = [...document.querySelectorAll('[data-padiem-design-video]')];
   if (!mounts.length || !document.title.includes('PADIEM Design')) return;
 
-  const reducedMotion = matchMedia('(prefers-reduced-motion: reduce)').matches;
+  const reducedMotion = window.matchMedia?.('(prefers-reduced-motion: reduce)').matches ?? false;
+  const supportsIntersectionObserver = 'IntersectionObserver' in window;
   const records = new Map();
 
   const setState = (mount, state) => {
     mount.dataset.videoState = state;
   };
 
+  // Reduced-motion and legacy browsers fail open to the first-party static
+  // fallback without creating or requesting a video element.
+  if (reducedMotion || !supportsIntersectionObserver) {
+    mounts.forEach(mount => setState(mount, 'fallback'));
+    return;
+  }
+
   const ensureVideo = mount => {
     if (records.has(mount)) return records.get(mount);
 
     const src = mount.dataset.videoSrc?.trim();
     if (!src) {
+      setState(mount, 'fallback');
+      return null;
+    }
+
+    let parsed;
+    try {
+      parsed = new URL(src, location.href);
+    } catch {
+      setState(mount, 'fallback');
+      return null;
+    }
+    if (parsed.protocol !== 'https:') {
       setState(mount, 'fallback');
       return null;
     }
@@ -26,14 +46,17 @@
     video.playsInline = true;
     video.preload = 'none';
     video.controls = false;
-    video.disablePictureInPicture = true;
+    if ('disablePictureInPicture' in video) video.disablePictureInPicture = true;
+    video.setAttribute('muted', '');
+    video.setAttribute('loop', '');
+    video.setAttribute('playsinline', '');
     video.setAttribute('aria-hidden', 'true');
     video.setAttribute('tabindex', '-1');
 
     const record = {
       mount,
       video,
-      src,
+      src: parsed.href,
       sourceAttached: false,
       failed: false,
       inView: false,
@@ -42,7 +65,7 @@
     video.addEventListener('loadeddata', () => {
       if (record.failed) return;
       setState(mount, 'ready');
-      if (record.inView && !document.hidden && !reducedMotion) {
+      if (record.inView && !document.hidden) {
         video.play().catch(() => setState(mount, 'paused'));
       }
     });
@@ -58,27 +81,24 @@
     });
 
     const failOpen = () => {
+      if (record.failed) return;
       record.failed = true;
       video.pause();
       video.removeAttribute('src');
-      video.load();
       video.remove();
       setState(mount, 'fallback');
     };
 
     video.addEventListener('error', failOpen, { once: true });
-    video.addEventListener('abort', () => {
-      if (!record.failed && !record.inView) setState(mount, 'paused');
-    });
 
     mount.append(video);
-    setState(mount, reducedMotion ? 'fallback' : 'idle');
+    setState(mount, 'idle');
     records.set(mount, record);
     return record;
   };
 
   const attachSource = record => {
-    if (!record || record.sourceAttached || record.failed || reducedMotion) return;
+    if (!record || record.sourceAttached || record.failed) return;
     record.video.src = record.src;
     record.video.preload = 'metadata';
     record.sourceAttached = true;
@@ -87,7 +107,7 @@
   };
 
   const play = record => {
-    if (!record || record.failed || reducedMotion || document.hidden) return;
+    if (!record || record.failed || document.hidden) return;
     attachSource(record);
     if (record.video.readyState >= 2) {
       record.video.play().catch(() => setState(record.mount, 'paused'));
@@ -100,8 +120,6 @@
   };
 
   mounts.forEach(ensureVideo);
-
-  if (reducedMotion) return;
 
   const observer = new IntersectionObserver(entries => {
     entries.forEach(entry => {


### PR DESCRIPTION
## SUPERSEDED BY PR #28

This preparatory Design video runtime is no longer the canonical integration path.

Its useful safety principles were absorbed into merged PR #28 / main:
- viewport-aware media loading
- pause/fallback behavior
- reduced-motion/static fallback
- fail-open media handling
- build-time media authority gates

Canonical production integration is now the reversible CURRENT/ALBUM exhibit system merged via #28 with R2 media under `media.padiem.net`.

Do not merge this PR separately. Closing as superseded, not failed.