### PR TITLE
prep(exhibit): harden PR #28 album runtime

### DIFF
--- a/docs/PADIEM_EXHIBIT_MODES_OPERATIONS_V1.md
+++ b/docs/PADIEM_EXHIBIT_MODES_OPERATIONS_V1.md
@@ -1,0 +1,215 @@
+# PADIEM Exhibit Modes Operations v1
+
+Status: staging above PR #28. This document becomes authoritative only when the accepted hardening is absorbed into the canonical exhibit PR/main.
+
+## 1. Purpose
+
+PADIEM keeps two independent public presentation modes for Products and Design.
+
+- `CURRENT` = the previously accepted cinematic / scroll-scrub presentation.
+- `ALBUM` = the new non-scroll collection presentation.
+
+The operational requirement is **reversibility, not replacement**. CURRENT source scenes and their renderers must not be deleted merely because ALBUM becomes the default.
+
+## 2. Mode authority
+
+Runtime authority lives in:
+
+`static/js/padiem-exhibit-config-v1.js`
+
+Expected shape:
+
+```js
+modes: {
+  products: 'album',
+  design: 'album',
+}
+```
+
+To restore the accepted previous presentation, change only the desired world:
+
+```js
+modes: {
+  products: 'current',
+  design: 'current',
+}
+```
+
+Products and Design are intentionally independent. Mixed operation is allowed:
+
+```js
+modes: {
+  products: 'album',
+  design: 'current',
+}
+```
+
+Do not restore a mode by deleting the other renderer or reconstructing old markup.
+
+## 3. Exact comparison overrides
+
+The public build supports explicit QA overrides without changing source authority:
+
+- `?exhibit=album`
+- `?exhibit=current`
+
+Internal comparison controls appear only when:
+
+- `?exhibitControls=1`
+
+The comparison control is a QA surface and must not be treated as the normal public navigation model.
+
+## 4. Renderer isolation
+
+When ALBUM is active:
+
+- legacy scroll-scrub background must not start;
+- CURRENT Design interaction runtime must return before mounting hidden studies;
+- CURRENT Products interaction runtime must return before mounting hidden studies;
+- hidden CURRENT infinite animation loops must not continue in the background.
+
+When CURRENT is active:
+
+- existing CURRENT behavior remains the accepted path;
+- ALBUM must not overlay or replace CURRENT DOM;
+- the query override must be sufficient to restore CURRENT without source restoration.
+
+## 5. Media registry authority
+
+Content/media authority lives in:
+
+`static/js/padiem-exhibit-registry-v1.js`
+
+Approved media origin:
+
+`https://media.padiem.net`
+
+Direct `r2.dev` and infrastructure-style deployment URLs such as `workers.dev` are forbidden on the public exhibit surface.
+
+Media filenames must be versioned (`-vN.mp4`) and must not use query-string cache busting.
+
+Current accepted R2 media objects:
+
+### Design
+
+1. `https://media.padiem.net/design/orbitmorph-v1.mp4`
+2. `https://media.padiem.net/design/emotion-path-helix-v1.mp4`
+3. `https://media.padiem.net/design/rotating-memory-index-v1.mp4`
+4. `https://media.padiem.net/design/living-media-sphere-v1.mp4`
+
+### Products
+
+1. `https://media.padiem.net/products/lovetree-mvp01-walkthrough-v1.mp4`
+2. `https://media.padiem.net/products/danjion-product-preview-v1.mp4`
+
+Products without approved real footage must remain static/fallback rather than receiving synthetic video.
+
+Current no-video products:
+
+- Padiem Chat — product is live, but public footage is not yet approved.
+- StoryMemory — private preview / still in development.
+- AI Free Radar — preparing.
+
+## 6. CTA authority
+
+Currently approved public product CTA:
+
+- Padiem Chat → `https://chat.padiem.net`
+
+Do not expose raw Workers, preview, local, or infrastructure URLs as official product CTAs.
+
+LoveTree and DanjiOn may show accepted product films without a public CTA until a branded destination is explicitly approved.
+
+## 7. Failure behavior
+
+R2 media is enhancement, not page authority.
+
+If `media.padiem.net` fails or is blocked:
+
+- Products and Design pages must remain usable;
+- selector/navigation must remain available;
+- first-party static/typographic fallback must remain visible;
+- page navigation, KO/EN, Company drawer and Home must remain functional;
+- a failed media URL should enter terminal fallback for the current page session rather than repeatedly re-requesting the same broken object.
+
+Reduced-motion users should not depend on video for meaning.
+
+## 8. Design collection authority
+
+The selected Design collection is:
+
+1. OrbitMorph Portal
+2. Emotion Path Helix
+3. Rotating Memory Index
+4. Living Media Sphere
+
+Rotating Memory Index must be described around the **right-side index / card transformation** interaction, not as a left-side click concept.
+
+The four were selected from the broader 108-study review. ALBUM should present them as a curated collection, not as another vertical scroll sequence.
+
+## 9. Product collection authority
+
+Registry order:
+
+1. Padiem Chat
+2. StoryMemory
+3. LoveTree
+4. DanjiOn
+5. AI Free Radar
+
+Real public footage currently exists only for LoveTree and DanjiOn.
+
+Do not fabricate current offers, providers, private StoryMemory source material, or unfinished Padiem Chat behavior merely to fill an empty media slot.
+
+## 10. Acceptance matrix before changing the default
+
+For both desktop and mobile verify:
+
+- ALBUM render
+- click selection
+- drag/swipe selection
+- ArrowLeft / ArrowRight
+- correct media mapping
+- LoveTree playback
+- DanjiOn playback
+- all four Design films
+- no fake media on no-video products
+- media failure fallback
+- KO/EN
+- Company drawer
+- main navigation
+- Home regression
+- console fatal errors = 0
+
+Then verify reversibility:
+
+- `?exhibit=current` restores CURRENT Design
+- `?exhibit=current` restores CURRENT Products
+- CURRENT scroll-scrub operates normally
+- `?exhibit=album` restores ALBUM
+
+## 11. Production rollback procedure
+
+If ALBUM has a production defect but the site itself is healthy:
+
+1. Do not delete ALBUM code or R2 objects.
+2. Change only the affected `modes.<world>` value from `album` to `current`.
+3. Build and exact-head preview.
+4. Confirm the affected world is CURRENT and the other world is unchanged.
+5. Deploy through the normal reviewed Netlify path.
+6. Keep the ALBUM implementation for repair and later reactivation.
+
+If R2 is the incident source, prefer the existing media emergency controls/fallback policy rather than reverting unrelated homepage code.
+
+## 12. Pull request lineage
+
+- PR #28 = canonical Album/Collection presentation integration candidate.
+- PR #29 = staging hardening above PR #28; do not merge directly to main.
+- PR #25 = earlier Design video runtime; safety logic may be absorbed, then superseded.
+- PR #27 = accepted LoveTree footage lineage; R2 media is already canonical, only unique useful UX such as chapter seek should be evaluated before superseding.
+
+## 13. Non-negotiable preservation rule
+
+**CURRENT must remain recoverable without recreating deleted source.**
+
+ALBUM may become the default, but it does not erase the previously accepted presentation.

--- a/docs/PADIEM_PUBLIC_MEDIA_LEDGER_V1.md
+++ b/docs/PADIEM_PUBLIC_MEDIA_LEDGER_V1.md
@@ -1,0 +1,101 @@
+# PADIEM Public Media Ledger v1
+
+Purpose: integrity ledger for public PADIEM exhibit media delivered through `media.padiem.net`.
+
+This ledger contains public object metadata only. Private archive locations, credentials, tokens, source IDs and unpublished media locators are intentionally excluded.
+
+## Delivery authority
+
+- Public media origin: `https://media.padiem.net`
+- R2 bucket role: media origin only
+- Public `r2.dev`: disabled
+- Homepage origin: `https://padiem.net`
+- Large MP4 files must not be committed to the homepage repository.
+- Query-string cache busting is not an approved versioning mechanism.
+- New public revisions use versioned object filenames (`-vN.mp4`).
+
+## Approved Design objects
+
+| Exhibit | Public object | Duration | Resolution | SHA-256 |
+| --- | --- | ---: | --- | --- |
+| OrbitMorph Portal | `https://media.padiem.net/design/orbitmorph-v1.mp4` | 17.8s | 1280×720 | `7fd66c69e34fe360086d1f5b7ba3d30a133a9f9b546db9c92584424f7c465f81` |
+| Emotion Path Helix | `https://media.padiem.net/design/emotion-path-helix-v1.mp4` | 17.0s | 1280×720 | `fa2d0e49197b86ec7e7dc9f7eedf0729d30f646ab5752d161521fdd19f73b741` |
+| Rotating Memory Index | `https://media.padiem.net/design/rotating-memory-index-v1.mp4` | 17.0s | 1280×720 | `6c78d811656f4fd2c68c960d9f6846114258b72f6978d169d2cf1de2a93f0a13` |
+| Living Media Sphere | `https://media.padiem.net/design/living-media-sphere-v1.mp4` | 20.0s | 1280×720 | `42ae08e323eade2ccb3a1e8637937077a8f0ddfcd06501f318608a9eb0fed6fe` |
+
+Accepted validation for all four:
+
+- source ↔ remote byte parity: PASS
+- public HTTP delivery: PASS
+- Range request `206`: PASS
+- CDN cache: PASS
+- query-cache normalization: PASS
+
+The combined Design reel is an archive/editorial convenience asset and is not part of the initial public R2 exhibit object set.
+
+## Approved Product objects
+
+| Product | Public object | Duration | Resolution | Public bytes | SHA-256 |
+| --- | --- | ---: | --- | ---: | --- |
+| LoveTree MVP01 walkthrough | `https://media.padiem.net/products/lovetree-mvp01-walkthrough-v1.mp4` | 58.04s | 1440×900 | 2,208,367 | `cd390fcc8374c762769a0915b9847c02d25d94d04e815ddb3d43081b0e6945eb` |
+| DanjiOn product preview | `https://media.padiem.net/products/danjion-product-preview-v1.mp4` | 59.366667s | 1440×900 | 4,375,700 | `0b456e58903d25010dceae4dd754e735173a8493128b2740dd3cb06c1f8aee81` |
+
+Accepted validation for both:
+
+- source ↔ remote byte parity: PASS
+- HTTP `200`: PASS
+- Range `bytes=0-3` → `206`: PASS
+- `Content-Range`: PASS
+- CDN MISS → HIT: PASS
+- query variants such as `?v=1` do not create an independent cache entry: PASS
+
+## Current object inventory authority
+
+Initial accepted public exhibit inventory = **6 objects**:
+
+```text
+design/orbitmorph-v1.mp4
+design/emotion-path-helix-v1.mp4
+design/rotating-memory-index-v1.mp4
+design/living-media-sphere-v1.mp4
+products/lovetree-mvp01-walkthrough-v1.mp4
+products/danjion-product-preview-v1.mp4
+```
+
+The bootstrap cache probe was positively identified, deleted and purged. It is not an accepted public object.
+
+## Products without approved video
+
+The absence of a video is intentional for:
+
+- Padiem Chat — public product footage not yet approved.
+- StoryMemory — private preview / still changing.
+- AI Free Radar — preparing.
+
+Do not fill these slots with synthetic or fabricated product footage merely for visual symmetry.
+
+## Replacement/versioning procedure
+
+When an approved media file materially changes:
+
+1. Do not overwrite the existing versioned object in place.
+2. Produce the new final master and calculate SHA-256 before upload.
+3. Upload to a new object name such as `-v2.mp4` using the remote R2 target.
+4. Read the remote object back and verify byte parity.
+5. Verify HTTP `200`, Range `206`, cache behavior and query normalization.
+6. Update the exhibit registry to the new versioned URL.
+7. Update this ledger with the new SHA-256 and metadata.
+8. Run exact-head browser fallback and regression QA before production.
+9. Retain or delete the old object only according to the media operations retention decision; never guess-delete unknown objects.
+
+## Incident verification
+
+If media corruption or unexpected content is suspected, compare the served/downloaded object SHA-256 with this ledger before changing homepage code.
+
+A media mismatch is a media incident first; it is not by itself evidence that the PADIEM homepage source should be rolled back.
+
+## Related authority
+
+- `docs/PADIEM_MEDIA_R2_OPERATIONS_V1.md` — hosting/cost/fallback operations.
+- `docs/PADIEM_EXHIBIT_MODES_OPERATIONS_V1.md` — CURRENT/ALBUM presentation switching and rollback.
+- `static/js/padiem-exhibit-registry-v1.js` — runtime exhibit content/media registry after canonical integration.

--- a/scripts/build-cinematic-site.mjs
+++ b/scripts/build-cinematic-site.mjs
@@ -27,6 +27,17 @@ if (/\.r2\.dev|workers\.dev/i.test(exhibitRegistryText)) {
 const exhibitMediaUrls = [...exhibitRegistryText.matchAll(/\bmedia:\s*'([^']*)'/g)]
   .map(match => match[1].trim())
   .filter(Boolean);
+const exhibitHrefUrls = [...exhibitRegistryText.matchAll(/\bhref:\s*'([^']*)'/g)]
+  .map(match => match[1].trim())
+  .filter(Boolean);
+const allowedPublicHrefs = new Set([
+  "https://chat.padiem.net",
+]);
+for (const href of exhibitHrefUrls) {
+  if (!allowedPublicHrefs.has(href)) {
+    throw new Error(`Unapproved public exhibit CTA: ${href}`);
+  }
+}
 const requiredExhibitMedia = new Set([
   "https://media.padiem.net/design/orbitmorph-v1.mp4",
   "https://media.padiem.net/design/emotion-path-helix-v1.mp4",

--- a/scripts/build-cinematic-site.mjs
+++ b/scripts/build-cinematic-site.mjs
@@ -12,6 +12,47 @@ import { join } from "node:path";
 const root = process.cwd();
 const publicDir = join(root, "public");
 const sourceHtml = join(root, "static", "html", "index1.html");
+const exhibitRegistryPath = join(root, "static", "js", "padiem-exhibit-registry-v1.js");
+
+// Album media is an explicit public authority boundary. Fail closed before any
+// publish output is created if a registry edit bypasses the R2/custom-domain
+// contract or reintroduces an infrastructure-style public URL.
+if (!existsSync(exhibitRegistryPath)) {
+  throw new Error("Required exhibit registry is missing: static/js/padiem-exhibit-registry-v1.js");
+}
+const exhibitRegistryText = readFileSync(exhibitRegistryPath, "utf8");
+if (/\.r2\.dev|workers\.dev/i.test(exhibitRegistryText)) {
+  throw new Error("Exhibit registry must not expose r2.dev or workers.dev URLs.");
+}
+const exhibitMediaUrls = [...exhibitRegistryText.matchAll(/\bmedia:\s*'([^']*)'/g)]
+  .map(match => match[1].trim())
+  .filter(Boolean);
+const requiredExhibitMedia = new Set([
+  "https://media.padiem.net/design/orbitmorph-v1.mp4",
+  "https://media.padiem.net/design/emotion-path-helix-v1.mp4",
+  "https://media.padiem.net/design/rotating-memory-index-v1.mp4",
+  "https://media.padiem.net/design/living-media-sphere-v1.mp4",
+  "https://media.padiem.net/products/lovetree-mvp01-walkthrough-v1.mp4",
+  "https://media.padiem.net/products/danjion-product-preview-v1.mp4",
+]);
+for (const required of requiredExhibitMedia) {
+  if (!exhibitMediaUrls.includes(required)) {
+    throw new Error(`Approved exhibit media is missing from the registry: ${required}`);
+  }
+}
+for (const src of exhibitMediaUrls) {
+  const url = new URL(src);
+  const validPath = url.pathname.startsWith("/design/") || url.pathname.startsWith("/products/");
+  if (url.origin !== "https://media.padiem.net" || !validPath) {
+    throw new Error(`Exhibit media must use https://media.padiem.net/design|products/: ${src}`);
+  }
+  if (url.search || url.hash) {
+    throw new Error(`Exhibit media URLs must not contain query strings or fragments: ${src}`);
+  }
+  if (!/-v\d+\.mp4$/i.test(url.pathname)) {
+    throw new Error(`Exhibit media filenames must be versioned and end in -vN.mp4: ${src}`);
+  }
+}
 
 // Always start from a clean publish directory so legacy committed/generated pages
 // cannot survive into a Netlify deploy.
@@ -123,8 +164,7 @@ for (const { source, dest } of showcasePages) {
   }
 
   // Mode config must execute before the legacy scroll-scrub runtime so ALBUM can
-  // skip that background entirely while CURRENT remains byte-for-byte behaviorally
-  // equivalent after the guard returns false.
+  // skip that background entirely while CURRENT remains behaviorally equivalent.
   if (!pageHtml.includes('padiem-exhibit-config-v1.js')) {
     pageHtml = pageHtml.replace('</body>', `  ${exhibitConfigScript}\n</body>`);
   }

--- a/static/js/padiem-album-exhibit-v1.js
+++ b/static/js/padiem-album-exhibit-v1.js
@@ -21,6 +21,7 @@
   if (!hero || !items.length) return;
 
   const reduced = matchMedia('(prefers-reduced-motion: reduce)').matches;
+  const hasIntersectionObserver = 'IntersectionObserver' in window;
   const esc = value => String(value ?? '').replace(/[&<>'\"]/g, char => ({
     '&': '&amp;', '<': '&lt;', '>': '&gt;', "'": '&#39;', '\"': '&quot;'
   })[char]);
@@ -173,7 +174,7 @@
 
   const ensureVideo = () => {
     const item = items[selected];
-    if (!item.media || reduced) {
+    if (!item.media || reduced || !hasIntersectionObserver) {
       detachVideo();
       return;
     }
@@ -214,7 +215,7 @@
     status.textContent = item.status || 'PADIEM DESIGN ORIGINAL';
     section.style.setProperty('--album-accent-rgb', item.accent);
     disc.style.setProperty('--album-accent-rgb', item.accent);
-    play.hidden = !item.media || reduced || failedMedia.has(item.media);
+    play.hidden = !item.media || reduced || !hasIntersectionObserver || failedMedia.has(item.media);
 
     if (item.href) {
       openLink.hidden = false;
@@ -303,7 +304,7 @@
     play.hidden = true;
   });
 
-  if ('IntersectionObserver' in window) {
+  if (hasIntersectionObserver) {
     new IntersectionObserver(entries => {
       entries.forEach(entry => {
         inView = entry.isIntersecting;
@@ -312,8 +313,7 @@
       });
     }, { threshold: .22, rootMargin: '120px 0px 120px' }).observe(section);
   } else {
-    inView = true;
-    ensureVideo();
+    detachVideo('fallback', 'STATIC FALLBACK');
   }
 
   document.addEventListener('visibilitychange', () => {

--- a/static/js/padiem-album-exhibit-v1.js
+++ b/static/js/padiem-album-exhibit-v1.js
@@ -242,7 +242,6 @@
 
   shelf.addEventListener('pointerdown', event => {
     pointerStart = { x: event.clientX, y: event.clientY };
-    shelf.setPointerCapture?.(event.pointerId);
   });
   shelf.addEventListener('pointerup', event => {
     if (!pointerStart) return;

--- a/static/js/padiem-album-exhibit-v1.js
+++ b/static/js/padiem-album-exhibit-v1.js
@@ -21,15 +21,22 @@
   if (!hero || !items.length) return;
 
   const reduced = matchMedia('(prefers-reduced-motion: reduce)').matches;
-  const esc = value => String(value ?? '').replace(/[&<>'"]/g, char => ({
-    '&': '&amp;', '<': '&lt;', '>': '&gt;', "'": '&#39;', '"': '&quot;'
+  const esc = value => String(value ?? '').replace(/[&<>'\"]/g, char => ({
+    '&': '&amp;', '<': '&lt;', '>': '&gt;', "'": '&#39;', '\"': '&quot;'
   })[char]);
+  const currentLanguage = () => document.body.dataset.lang === 'en' ? 'en' : 'ko';
+  const localizedTitle = item => currentLanguage() === 'en' ? item.title : (item.titleKo || item.title);
 
   document.body.classList.add('px-exhibit-album', `px-exhibit-${pageKey}`);
 
   const ledger = hero.querySelector('.world-hero-ledger dl');
   if (ledger) {
-    ledger.innerHTML = items.map(item => `<div><dt>${esc(item.no)}</dt><dd>${esc(item.titleKo || item.title)} · ${esc(item.kicker.split(' / ')[0])}</dd></div>`).join('');
+    ledger.innerHTML = items.map(item => {
+      const ko = `${item.titleKo || item.title} · ${item.kicker.split(' / ')[0]}`;
+      const en = `${item.title} · ${item.kicker.split(' / ')[0]}`;
+      const initial = currentLanguage() === 'en' ? en : ko;
+      return `<div><dt>${esc(item.no)}</dt><dd data-copy-ko="${esc(ko)}" data-copy-en="${esc(en)}">${esc(initial)}</dd></div>`;
+    }).join('');
   }
 
   const section = document.createElement('section');
@@ -94,17 +101,19 @@
   hero.insertAdjacentElement('afterend', section);
 
   const shelf = section.querySelector('.px-album-shelf');
-  shelf.innerHTML = items.map((item, index) => `
+  shelf.innerHTML = items.map((item, index) => {
+    const initialTitle = localizedTitle(item);
+    return `
     <button class="px-album-sleeve" type="button" role="option" aria-selected="${index === 0}" data-index="${index}" style="--item-accent:${esc(item.accent)}">
       <span class="px-sleeve-edge"></span>
       <span class="px-sleeve-face">
         <span class="px-sleeve-meta"><b>${esc(item.no)}</b><em>${esc(item.status || 'DESIGN STUDY')}</em></span>
         <span class="px-sleeve-glyph">${esc(item.glyph)}</span>
-        <span class="px-sleeve-title">${esc(item.titleKo || item.title)}</span>
+        <span class="px-sleeve-title" data-copy-ko="${esc(item.titleKo || item.title)}" data-copy-en="${esc(item.title)}">${esc(initialTitle)}</span>
         <span class="px-sleeve-line"></span>
       </span>
-    </button>
-  `).join('');
+    </button>`;
+  }).join('');
 
   const video = section.querySelector('.px-album-video');
   const media = section.querySelector('.px-album-media');
@@ -131,8 +140,7 @@
   let inView = false;
   let loadedSrc = '';
   let pointerStart = null;
-
-  const currentLanguage = () => document.body.dataset.lang === 'en' ? 'en' : 'ko';
+  const failedMedia = new Set();
 
   const wrappedDelta = (index, active) => {
     let delta = index - active;
@@ -153,22 +161,28 @@
     });
   };
 
-  const detachVideo = () => {
+  const detachVideo = (state = 'fallback', message = 'STATIC FALLBACK') => {
     video.pause();
     video.removeAttribute('src');
     video.load();
     loadedSrc = '';
-    media.dataset.state = 'fallback';
-    mediaState.textContent = 'STATIC FALLBACK';
+    media.dataset.state = state;
+    mediaState.textContent = message;
     progress.style.transform = 'scaleX(0)';
   };
 
   const ensureVideo = () => {
     const item = items[selected];
-    if (!item.media || !inView || reduced) {
-      if (!item.media || reduced) detachVideo();
+    if (!item.media || reduced) {
+      detachVideo();
       return;
     }
+    if (failedMedia.has(item.media)) {
+      detachVideo('error', 'MEDIA OFFLINE · FALLBACK');
+      play.hidden = true;
+      return;
+    }
+    if (!inView) return;
     if (loadedSrc !== item.media) {
       video.pause();
       media.dataset.state = 'loading';
@@ -200,6 +214,7 @@
     status.textContent = item.status || 'PADIEM DESIGN ORIGINAL';
     section.style.setProperty('--album-accent-rgb', item.accent);
     disc.style.setProperty('--album-accent-rgb', item.accent);
+    play.hidden = !item.media || reduced || failedMedia.has(item.media);
 
     if (item.href) {
       openLink.hidden = false;
@@ -251,7 +266,8 @@
   });
 
   play.addEventListener('click', () => {
-    if (!items[selected].media) return;
+    const item = items[selected];
+    if (!item.media || failedMedia.has(item.media)) return;
     if (!loadedSrc) ensureVideo();
     if (video.paused) video.play().catch(() => {});
     else video.pause();
@@ -276,9 +292,16 @@
     progress.style.transform = `scaleX(${ratio})`;
   });
   video.addEventListener('error', () => {
+    const failedSrc = loadedSrc || items[selected].media;
+    if (failedSrc) failedMedia.add(failedSrc);
+    video.pause();
+    video.removeAttribute('src');
+    video.load();
+    loadedSrc = '';
     media.dataset.state = 'error';
     mediaState.textContent = 'MEDIA OFFLINE · FALLBACK';
-    loadedSrc = '';
+    progress.style.transform = 'scaleX(0)';
+    play.hidden = true;
   });
 
   if ('IntersectionObserver' in window) {

--- a/static/js/padiem-live-exhibits-v1.js
+++ b/static/js/padiem-live-exhibits-v1.js
@@ -1,4 +1,12 @@
 (() => {
+  const config = window.PADIEM_EXHIBIT_CONFIG;
+  if (config) {
+    const params = new URLSearchParams(location.search);
+    const requested = params.get(config.queryParam);
+    const mode = config.allowedModes.includes(requested) ? requested : config.modes.design;
+    if (mode === 'album') return;
+  }
+
   const frames = [...document.querySelectorAll('.world-media-frame')];
   if (frames.length < 4 || !document.title.includes('PADIEM Design')) return;
 

--- a/static/js/padiem-product-exhibits-v1.js
+++ b/static/js/padiem-product-exhibits-v1.js
@@ -1,4 +1,12 @@
 (() => {
+  const config = window.PADIEM_EXHIBIT_CONFIG;
+  if (config) {
+    const params = new URLSearchParams(location.search);
+    const requested = params.get(config.queryParam);
+    const mode = config.allowedModes.includes(requested) ? requested : config.modes.products;
+    if (mode === 'album') return;
+  }
+
   if (!document.title.includes('PADIEM Products')) return;
 
   const frames = [...document.querySelectorAll('.world-media-frame')];


### PR DESCRIPTION
## SUPERSEDED STAGING — absorbed into PR #28

This PR was intentionally a staging branch above PR #28, not a main-target integration lane.

The accepted hardening has now been directly absorbed into canonical PR #28 (`feat/padiem-album-exhibit-v1`) because the connector could not transition this Draft PR to Ready (`fullDatabaseId` GraphQL schema error), and GitHub correctly refused merging a Draft PR.

Absorbed into PR #28:
- direct sleeve click fix (remove pointer capture retargeting)
- terminal media fail-open
- no-media playback-control suppression
- KO/EN initial Album ledger/sleeve state
- CURRENT Design/Product runtime isolation in ALBUM mode
- no-IntersectionObserver static fallback
- media/CTA build authority gates
- exhibit mode operations document
- public media integrity ledger

Canonical PR #28 final absorbed head at closeout time:
`68a98ba8a7439698cc5384f86ff1c61d5fe37a24`

This staging PR is closed as superseded, not because the hardening failed. Do not merge it separately.